### PR TITLE
Add when_file_changed to toplevel import

### DIFF
--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -26,6 +26,7 @@ from .decorators import when  # noqa
 from .decorators import when_not  # noqa
 from .decorators import not_unless  # noqa
 from .decorators import only_once  # noqa
+from .decorators import when_file_changed  # noqa
 
 from . import bus
 from charmhelpers.core import hookenv


### PR DESCRIPTION
Fixes import error when doing `from charms.reactive import when_file_changed`

Makes this importable like the other decorators

Signed-off-by: Adam Stokes <adam.stokes@ubuntu.com>