### PR TITLE
Issue18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ docs/_build
 .project
 .pydevproject
 .settings
+*~

--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -53,6 +53,7 @@ def main(relation_name=None):
     hookenv.atexit(flush_kv)
     try:
         bus.discover()
+        hookenv._run_atstart()
         bus.dispatch()
     except SystemExit as x:
         if x.code is None or x.code == 0:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,11 +26,13 @@ class TestReactiveMain(unittest.TestCase):
     @mock.patch.object(unitdata, '_KV')
     @mock.patch.object(reactive.bus, 'dispatch')
     @mock.patch.object(reactive.bus, 'discover')
+    @mock.patch.object(reactive.hookenv, '_run_atstart')
     @mock.patch.object(reactive.hookenv, 'log')
     @mock.patch.object(reactive.hookenv, 'hook_name')
-    def test_main(self, hook_name, log, discover, dispatch, _KV):
+    def test_main(self, hook_name, log, _run_atstart, discover, dispatch, _KV):
         hook_name.return_value = 'hook_name'
         reactive.main()
+        _run_atstart.assert_called_once_with()
         log.assert_called_once_with('Reactive main running for hook hook_name', level=reactive.hookenv.INFO)
         discover.assert_called_once_with()
         dispatch.assert_called_once_with()


### PR DESCRIPTION
Invoke hookenv._run_atstart() after discovery but before dispatch.

I need this to integrate charmhelpers.coordinator with the reactive framework, so that charms can request locks using set_state, and handlers invoked after the leader grants locks using standard @when decorators.