### PR TITLE
Adjust PATH and PYTHONPATH to work around bundled deps

### DIFF
--- a/bin/charms.reactive.sh
+++ b/bin/charms.reactive.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export PATH=$PATH:$CHARM_DIR/bin
+export PYTHONPATH=$PYTHONPATH:$CHARM_DIR/lib
+
 if [[ "$0" == "$BASH_SOURCE" ]]; then
     echo 'This file contains helpers for developing reactive charms in Bash.'
     echo

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -139,7 +139,8 @@ There are helpers for writing handlers in bash.  For example:
 
 .. code-block:: bash
 
-    source `which charms.reactive.sh`
+    #!/bin/bash
+    source $CHARM_DIR/bin/charms.reactive.sh
 
     @when 'db.database.available' 'admin-pass'
     function render_config() {


### PR DESCRIPTION
Because the deps in basic are installed into $CHARM_DIR/{lib,bin} and not at the system level, bash handlers will fail inside `charms.reactive.sh` without this work-around.