### PR TITLE
source charms.reactive.sh better

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,7 +140,7 @@ There are helpers for writing handlers in bash.  For example:
 .. code-block:: bash
 
     #!/bin/bash
-    source `which charms.reactive.sh`
+    source charms.reactive.sh
 
     @when 'db.database.available' 'admin-pass'
     function render_config() {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -140,7 +140,7 @@ There are helpers for writing handlers in bash.  For example:
 .. code-block:: bash
 
     #!/bin/bash
-    source $CHARM_DIR/bin/charms.reactive.sh
+    source `which charms.reactive.sh`
 
     @when 'db.database.available' 'admin-pass'
     function render_config() {


### PR DESCRIPTION
The example doc for bash handlers assumes charms.reactive.sh is in the CHARM_DIR/bin directory.  Source `which charms.reactive.sh` instead.