### PR TITLE
Allow filename arguments to be a callable, defering their generation.

### DIFF
--- a/charms/reactive/decorators.py
+++ b/charms/reactive/decorators.py
@@ -106,7 +106,8 @@ def when_file_changed(*filenames, **kwargs):
     """
     Register the decorated function to run when one or more files have changed.
 
-    :param list filenames: The names of one or more files to check for changes.
+    :param list filenames: The names of one or more files to check for changes
+        (a callable returning the name is also accepted).
     :param str hash_type: The type of hash to use for determining if a file has
         changed.  Defaults to 'md5'.  Must be given as a kwarg.
     """

--- a/charms/reactive/helpers.py
+++ b/charms/reactive/helpers.py
@@ -122,7 +122,8 @@ def any_file_changed(filenames, hash_type='md5'):
     Check if any of the given files have changed since the last time this
     was called.
 
-    :param list filenames: Names of files to check.
+    :param list filenames: Names of files to check. Accepts callables returning
+        the filename.
     :param str hash_type: Algorithm to use to check the files.
     """
     changed = False

--- a/charms/reactive/helpers.py
+++ b/charms/reactive/helpers.py
@@ -127,6 +127,10 @@ def any_file_changed(filenames, hash_type='md5'):
     """
     changed = False
     for filename in filenames:
+        if callable(filename):
+            filename = str(filename())
+        else:
+            filename = str(filename)
         old_hash = unitdata.kv().get('reactive.files_changed.%s' % filename)
         new_hash = host.file_hash(filename, hash_type=hash_type)
         if old_hash != new_hash:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -155,6 +155,16 @@ class TestReactiveHelpers(unittest.TestCase):
             mock.call('file3', hash_type='md5'),
         ])
 
+    @mock.patch('charmhelpers.core.host.file_hash')
+    def test_any_file_changed_argtypes(self, file_hash):
+        file_hash.return_value = 'beep'
+        # A filename may be a callable, in which case it is called and
+        # the result used, and are cast to strings.
+        reactive.helpers.any_file_changed(['one', lambda: 'two', 3])
+        file_hash.assert_has_calls([mock.call('one', hash_type='md5'),
+                                    mock.call('two', hash_type='md5'),
+                                    mock.call('3', hash_type='md5')])
+
     def test_was_invoked(self):
         assert not reactive.helpers.was_invoked('foo')
         assert not reactive.helpers.was_invoked('foo')


### PR DESCRIPTION
Allow filename arguments to any_file_changed be callables, so the generation of the filename is deferred until the check is being made.

I currently have a handler decorated with @when_file_changed(postgresql_conf_path()). postgresq_conf_path generates the correct filename using the service configuration. This means the module cannot be imported by my test harness without first installing a mock (which is not a good option, as that mock may not be suitable for all tests). By changing this to @when_file_changed(postgresql_conf_path), my module is easily importable and easier to test.