### PR TITLE
Blacklist common non-executable files

### DIFF
--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -444,6 +444,13 @@ def _load_module(filepath):
 
 
 def _register_handlers_from_file(filepath):
+    no_exec_blacklist = (
+        '.md', '.yaml', '.txt', '.ini',
+        'makefile', '.gitignore',
+        'copyright', 'license')
+    if filepath.lower().endswith(no_exec_blacklist):
+        # Don't load handlers with one of the blacklisted extensions
+        return
     if filepath.endswith('.py'):
         _load_module(filepath)
     elif os.access(filepath, os.X_OK):

--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -13,10 +13,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
-
 import os
 import re
 import sys
+import errno
 import subprocess
 from itertools import chain
 from functools import partial
@@ -42,6 +42,14 @@ _log_opts = os.environ.get('REACTIVE_LOG_OPTS', '').split(',')
 LOG_OPTS = {
     'register': 'register' in _log_opts,
 }
+
+
+class BrokenHandlerException(Exception):
+    def __init__(self, path):
+        message = ("File at '{}' is marked as executable but "
+                   "execution failed. Only handler files may be marked "
+                   "as executable.".format(path))
+        super(BrokenHandlerException, self).__init__(message)
 
 
 class State(str):
@@ -328,7 +336,12 @@ class ExternalHandler(Handler):
         # flush to ensure external process can see states as they currently
         # are, and write states (flush releases lock)
         unitdata.kv().flush()
-        proc = subprocess.Popen([self._filepath, '--test'], stdout=subprocess.PIPE, env=os.environ)
+        try:
+            proc = subprocess.Popen([self._filepath, '--test'], stdout=subprocess.PIPE, env=os.environ)
+        except OSError as oserr:
+            if oserr.errno == errno.ENOEXEC:
+                raise BrokenHandlerException(self._filepath)
+            raise oserr
         self._test_output, _ = proc.communicate()
         return proc.returncode == 0
 


### PR DESCRIPTION
 - Blacklist common non-executable files. 
 - Better error message on `OSError [Errno 8]`

I did a quick check on interfaces.juju.solutions to see what non-exec files are present in interface repos. I'm not sure if this is the best place for the no_exec_blacklist tuple since `charm build` is going to need the same list for its warnings. See https://github.com/juju-solutions/charms.reactive/issues/54