### PR TITLE
Cache handler args in case handler is invoked more than once

### DIFF
--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -267,7 +267,10 @@ class Handler(object):
         """
         Lazily evaluate the args.
         """
-        return list(chain.from_iterable(self._args))
+        if not hasattr(self, '_args_evaled'):
+            # cache the args in case handler is re-invoked due to states change
+            self._args_evaled = list(chain.from_iterable(self._args))
+        return self._args_evaled
 
     def invoke(self):
         """

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -103,6 +103,11 @@ class TestReactiveDecorators(unittest.TestCase):
         action.assert_called_once_with('rel')
         self.assertEqual(reactive.bus.Handler._CONSUMED_STATES, set(['foo', 'bar', 'qux']))
 
+        action.reset_mock()
+        assert handler.test()
+        handler.invoke()
+        action.assert_called_once_with('rel')
+
     @mock.patch.object(reactive.decorators, 'when_all')
     def test_when(self, when_all):
         @reactive.when('foo', 'bar', 'qux')


### PR DESCRIPTION
Fixes #64

Reinvoking handlers should be rare, but can happen if a state is removed and re-added, or if `@when_any` is used.