### PR TITLE
Allow pluggable alternatives to RelationBase

### DIFF
--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -1,12 +1,12 @@
-# Copyright 2014-2015 Canonical Limited.
+# Copyright 2014-2016 Canonical Limited.
 #
-# This file is part of charm-helpers.
+# This file is part of charms.reactive
 #
-# charm-helpers is free software: you can redistribute it and/or modify
+# charms.reactive is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3 as
 # published by the Free Software Foundation.
 #
-# charm-helpers is distributed in the hope that it will be useful,
+# charms.reactive is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
@@ -69,7 +69,7 @@ def main(relation_name=None):
     hookenv.atexit(flush_kv)
     if hookenv.hook_name().endswith('-relation-departed'):
         def depart_conv():
-            rel = RelationBase.from_name(hookenv.relation_type())
+            rel = relations.relation_from_name(hookenv.relation_type())
             rel.conversation().depart()
         hookenv.atexit(depart_conv)
     try:

--- a/charms/reactive/altrelations.py
+++ b/charms/reactive/altrelations.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Canonical Limited.
+#
+# This file is part of charms.reactive.
+#
+# charms.reactive is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# charms.reactive is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
+
+from charms.reactive import get_state, set_state
+from charms.reactive.relations import RelationFactory
+
+
+class MinimalRelationBase(RelationFactory):
+    def __init__(self, relation_name):
+        self.relation_name = relation_name
+
+    def set_state(self, state):
+        """
+        Set state, tied to this relation.
+
+        Usage:
+
+            @hook('{requires:my-interface}-relation-{joined,changed}')
+            def changed(self):
+                self.set_state('{relation_name}.available')
+        """
+        set_state(
+            state.format(relation_name=self.relation_name),
+            {'relation': self.relation_name})
+
+    @classmethod
+    def from_name(cls, relation_name):
+        return cls(relation_name)
+
+    @classmethod
+    def from_state(cls, state):
+        value = get_state(state)
+        if value is None:
+            return None
+        relation_name = value['relation']
+        return cls.from_name(relation_name)

--- a/charms/reactive/decorators.py
+++ b/charms/reactive/decorators.py
@@ -1,12 +1,12 @@
-# Copyright 2014-2015 Canonical Limited.
+# Copyright 2014-2016 Canonical Limited.
 #
-# This file is part of charm-helpers.
+# This file is part of charms.reactive
 #
-# charm-helpers is free software: you can redistribute it and/or modify
+# charms.reactive is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3 as
 # published by the Free Software Foundation.
 #
-# charm-helpers is distributed in the hope that it will be useful,
+# charms.reactive is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
@@ -22,7 +22,7 @@ from charms.reactive.bus import Handler
 from charms.reactive.bus import get_states
 from charms.reactive.bus import _action_id
 from charms.reactive.bus import _short_action_id
-from charms.reactive.relations import RelationBase
+from charms.reactive.relations import relation_from_name, relation_from_state
 from charms.reactive.helpers import _hook
 from charms.reactive.helpers import _when_all
 from charms.reactive.helpers import _when_any
@@ -58,7 +58,7 @@ def hook(*hook_patterns):
     def _register(action):
         def arg_gen():
             # use a generator to defer calling of hookenv.relation_type, for tests
-            rel = RelationBase.from_name(hookenv.relation_type())
+            rel = relation_from_name(hookenv.relation_type())
             if rel:
                 yield rel
 
@@ -90,7 +90,7 @@ def when_all(*desired_states):
     def _register(action):
         handler = Handler.get(action)
         handler.add_predicate(partial(_when_all, desired_states))
-        handler.add_args(filter(None, map(RelationBase.from_state, desired_states)))
+        handler.add_args(filter(None, map(relation_from_state, desired_states)))
         handler.register_states(desired_states)
         return action
     return _register
@@ -105,7 +105,7 @@ def when_any(*desired_states):
     parameter bindings ambiguous.  Therefore, it is not generally recommended
     to use this with relation states; however, if you do need to, you can get
     the relation instance associated with a state using
-    :func:`~charms.reactive.relations.RelationBase.from_state`.
+    :func:`~charms.reactive.relations.relation_from_state`.
 
     Note that handlers whose conditions match are triggered at least once per
     hook invocation.

--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -1,12 +1,12 @@
-# Copyright 2014-2015 Canonical Limited.
+# Copyright 2014-2016 Canonical Limited.
 #
-# This file is part of charm-helpers.
+# This file is part of charms.reactive
 #
-# charm-helpers is free software: you can redistribute it and/or modify
+# charms.reactive is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3 as
 # published by the Free Software Foundation.
 #
-# charm-helpers is distributed in the hope that it will be useful,
+# charms.reactive is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Lesser General Public License for more details.
@@ -33,6 +33,103 @@ from charms.reactive.bus import StateList
 # arbitrary obj instances to use as defaults instead of None
 ALL = object()
 TOGGLE = object()
+
+
+def relation_from_name(relation_name):
+    """The object used for interacting with the named relations, or None.
+
+    This will be a RelationBase instance, unless the interface is using
+    a custom implementation.
+    """
+    if relation_name is None:
+        return None
+    factory = relation_factory(relation_name)
+    if factory:
+        return factory.from_name(relation_name)
+
+
+def relation_from_state(state):
+    """The object used for interacting with relations tied to a state, or None.
+
+    This will be a RelationBase instance, unless the interface is using
+    a custom implementation.
+    """
+    value = get_state(state)
+    if value is None:
+        return None
+    relation_name = value['relation']
+    factory = relation_factory(relation_name)
+    if factory:
+        return factory.from_state(state)
+
+
+class RelationFactory(object):
+    """Produce objects for interacting with a relation.
+
+    Interfaces choose which RelationFactory is used for their relations
+    by adding a RelationFactory subclass to
+    ``$CHARM_DIR/hooks/relations/{interface}/{provides,requires,peer}.py``.
+    This is normally a RelationBase subclass.
+    """
+    @classmethod
+    def from_name(cls, relation_name):
+        raise NotImplementedError()
+
+    @classmethod
+    def from_state(cls, state):
+        raise NotImplementedError()
+
+
+def relation_factory(relation_name):
+    """Get the RelationFactory for the given relation name.
+
+    Looks for a RelationFactory in the first file matching:
+    ``$CHARM_DIR/hooks/relations/{interface}/{provides,requires,peer}.py``
+    """
+    role, interface = hookenv.relation_to_role_and_interface(relation_name)
+    hooks_dir = os.path.join(hookenv.charm_dir(), 'hooks')
+    try:
+        filepath = os.path.join(hooks_dir, 'relations',
+                                interface, role + '.py')
+        module = _load_module(filepath)
+        return _find_relation_factory(module)
+    except ImportError:
+        hookenv.log('Missing or invalid hooks/relations/{}/{}.py'
+                    ''.format(interface, role), hookenv.WARNING)
+        return None
+
+
+def _find_relation_factory(module):
+    """
+    Attempt to find a RelationFactory subclass in the module.
+
+    Note: RelationFactory and RelationBase are ignored so they may
+    be imported to be used as base classes without fear.
+    """
+    # All the RelationFactory subclasses
+    candidates = [o for o in (getattr(module, attr) for attr in dir(module))
+                  if (o is not RelationFactory and
+                      o is not RelationBase and
+                      isclass(o) and
+                      issubclass(o, RelationFactory))]
+
+    # Filter out any factories that are superclasses of another factory
+    # (none of the other factories subclass it). This usually makes
+    # the explict check for RelationBase and RelationFactory unnecessary.
+    candidates = [c1 for c1 in candidates
+                  if not any(issubclass(c2, c1) for c2 in candidates
+                             if c1 is not c2)]
+
+    if not candidates:
+        hookenv.log('No RelationFactory found in {}'.format(module.__path__),
+                    hookenv.WARNING)
+        return None
+
+    if len(candidates) > 1:
+        raise RuntimeError('Too many RelationFactory found in {}'
+                           ''.format(module.__path__))
+
+    return candidates[0]
 
 
 class scopes(object):
@@ -92,9 +189,9 @@ class AutoAccessors(type):
         return __accessor
 
 
-class RelationBase(with_metaclass(AutoAccessors, object)):
+class RelationBase(with_metaclass(AutoAccessors, RelationFactory)):
     """
-    The base class for all relation implementations.
+    A base class for relation implementations.
     """
     _cache = {}
 
@@ -223,7 +320,8 @@ class RelationBase(with_metaclass(AutoAccessors, object)):
         """
         for attr in dir(module):
             candidate = getattr(module, attr)
-            if isclass(candidate) and issubclass(candidate, cls) and candidate is not cls:
+            if (isclass(candidate) and issubclass(candidate, cls) and
+                    candidate is not RelationBase):
                 return candidate
         return None
 
@@ -714,17 +812,17 @@ def _migrate_conversations():
 def relation_call(method, relation_name=None, state=None, *args):
     """Invoke a method on the class implementing a relation via the CLI"""
     if relation_name:
-        relation = RelationBase.from_name(relation_name)
+        relation = relation_from_name(relation_name)
         if relation is None:
             raise ValueError('Relation not found: %s' % relation_name)
     elif state:
-        relation = RelationBase.from_state(state)
+        relation = relation_from_state(state)
         if relation is None:
             raise ValueError('Relation not found: %s' % state)
     else:
         raise ValueError('Must specify either relation_name or state')
     result = getattr(relation, method)(*args)
-    if method == 'conversations':
+    if isinstance(relation, RelationBase) and method == 'conversations':
         # special case for conversations to make them work from CLI
         result = [c.scope for c in result]
     return result

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -1,8 +1,8 @@
-# Copyright 2014-2015 Canonical Limited.
+# Copyright 2014-2016 Canonical Limited.
 #
-# This file is part of charm-helpers.
+# This file is part of charms.reactive.
 #
-# charm-helpers is free software: you can redistribute it and/or modify
+# charms.reactive is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3 as
 # published by the Free Software Foundation.
 #
@@ -447,10 +447,11 @@ class TestReactiveBus(unittest.TestCase):
 
     @attr('slow')
     @mock.patch.dict('sys.modules')
+    @mock.patch('charmhelpers.core.hookenv.relation_to_role_and_interface')
     @mock.patch('charmhelpers.core.hookenv.relation_type')
     @mock.patch('charmhelpers.core.hookenv.hook_name')
     @mock.patch('charmhelpers.core.hookenv.charm_dir')
-    def test_full_stack(self, charm_dir, hook_name, relation_type):
+    def test_full_stack(self, charm_dir, hook_name, relation_type, rtrai):
         test_dir = os.path.dirname(__file__)
         charm_dir.return_value = os.path.join(test_dir, 'data')
         hook_name.return_value = 'config-changed'
@@ -499,6 +500,9 @@ class TestReactiveBus(unittest.TestCase):
 
             hook_name.return_value = 'test-rel-relation-joined'
             relation_type.return_value = 'test-rel'
+            rtrai.return_value = ('requires', 'test')
+            self.assertIsNotNone(reactive.relations.relation_factory('test-rel'))
+            self.assertIsNotNone(reactive.relations.relation_factory('test-rel').from_name('test'))
             with mock.patch.dict(os.environ, {'JUJU_HOOK_NAME': 'test-rel-relation-joined'}):
                 reactive.bus.dispatch()
             assert reactive.helpers.all_states('test-rel.ready')

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,8 +1,8 @@
-# Copyright 2014-2015 Canonical Limited.
+# Copyright 2014-2016 Canonical Limited.
 #
-# This file is part of charm-helpers.
+# This file is part of charms.reactive.
 #
-# charm-helpers is free software: you can redistribute it and/or modify
+# charms.reactive is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License version 3 as
 # published by the Free Software Foundation.
 #
@@ -15,6 +15,7 @@
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import types
 import mock
 import unittest
 
@@ -24,6 +25,96 @@ from charms.reactive import relations
 
 class DummyRelationSubclass(relations.RelationBase):
     auto_accessors = ['field-one', 'field-two']
+
+
+class TestFactory(unittest.TestCase):
+    @mock.patch.object(relations.hookenv, 'log')
+    @mock.patch.object(relations, '_load_module')
+    @mock.patch.object(relations.hookenv, 'charm_dir')
+    @mock.patch.object(relations.hookenv, 'relation_to_role_and_interface')
+    def test_relation_factory_import_fail(self, relation_to_role_and_interface,
+                                          charm_dir, load_module, log):
+        relation_to_role_and_interface.return_value = ('role', 'interface')
+        charm_dir.return_value = 'charm_dir'
+        load_module.side_effect = ImportError
+        self.assertIsNone(relations.relation_factory('relname'))
+        relation_to_role_and_interface.assert_called_once_with('relname')
+        load_module.assert_called_once_with(
+            'charm_dir/hooks/relations/interface/role.py')
+        log.assert_called_once_with(mock.ANY, relations.hookenv.WARNING)
+
+    @mock.patch.object(relations, '_find_relation_factory')
+    @mock.patch.object(relations.hookenv, 'log')
+    @mock.patch.object(relations, '_load_module')
+    @mock.patch.object(relations.hookenv, 'charm_dir')
+    @mock.patch.object(relations.hookenv, 'relation_to_role_and_interface')
+    def test_relation_factory(self, relation_to_role_and_interface,
+                              charm_dir, load_module, log, find_factory):
+        relation_to_role_and_interface.return_value = ('role', 'interface')
+        charm_dir.return_value = 'charm_dir'
+        load_module.return_value = 'module'
+        find_factory.return_value = 'fact'
+
+        self.assertEqual(relations.relation_factory('relname'), 'fact')
+        relation_to_role_and_interface.assert_called_once_with('relname')
+        load_module.assert_called_once_with(
+            'charm_dir/hooks/relations/interface/role.py')
+        find_factory.assert_called_once_with('module')
+
+    def test_find_relation_factory(self):
+        mod = types.ModuleType('mod')
+        mod.__path__ = 'here'
+
+        # Noise to be ignored
+        mod.RelationFactory = relations.RelationFactory
+        mod.RelationBase = relations.RelationBase
+
+        # One subclass of RelationFactory
+        class Rel(relations.RelationFactory):
+            pass
+        mod.Rel = Rel
+        self.assertIs(relations._find_relation_factory(mod), Rel)
+
+        # One subclass of RelationBase
+        class Rel2(relations.RelationBase):
+            pass
+        del mod.Rel
+        mod.Rel2 = Rel2
+        self.assertIs(relations._find_relation_factory(mod), Rel2)
+
+        # Subclass, and a subclass of it.
+        class Rel3(Rel2):
+            pass
+        mod.Rel3 = Rel3
+        self.assertIs(relations._find_relation_factory(mod), Rel3)
+
+        # A 2nd valid choice
+        mod.Rel4 = Rel3
+        with self.assertRaises(RuntimeError):
+            relations._find_relation_factory(mod)
+
+    def test_relation_from_name_missing_name(self):
+        self.assertIsNone(relations.relation_from_name(None))
+
+    @mock.patch.object(relations, 'relation_factory')
+    def test_relation_from_name_missing_factory(self, relation_factory):
+        relation_factory.return_value = None
+        self.assertIsNone(relations.relation_from_name('relname'))
+        relation_factory.assert_called_once_with('relname')
+
+    @mock.patch.object(relations, 'relation_factory')
+    def test_relation_from_name(self, relation_factory):
+        relation_factory('relname').from_name.return_value = 'relinstance'
+        relation_factory.reset_mock()
+
+        self.assertEqual(relations.relation_from_name('relname'),
+                         'relinstance')
+
+        relation_factory.assert_called_once_with('relname')
+        relation_factory('relname').from_name.assert_called_once_with('relname')
+
+
+
 
 
 class TestAutoAccessors(unittest.TestCase):
@@ -605,11 +696,11 @@ class TestMigrateConvs(unittest.TestCase):
 class TestRelationCall(unittest.TestCase):
     def setUp(self):
         self.r1 = mock.Mock(name='r1')
-        from_name_p = mock.patch.object(relations.RelationBase, 'from_name')
+        from_name_p = mock.patch.object(relations, 'relation_from_name')
         self.from_name = from_name_p.start()
         self.addCleanup(from_name_p.stop)
         self.from_name.side_effect = lambda name: self.r1
-        from_state_p = mock.patch.object(relations.RelationBase, 'from_state')
+        from_state_p = mock.patch.object(relations, 'relation_from_state')
         self.from_state = from_state_p.start()
         self.addCleanup(from_state_p.stop)
         self.from_state.side_effect = lambda name: self.r1
@@ -634,7 +725,10 @@ class TestRelationCall(unittest.TestCase):
         self.r1.method.assert_called_once_with('arg1', 'arg2')
         self.from_state.assert_called_once_with('state')
 
-    def test_call_conversations(self):
+    @mock.patch.object(relations, 'isinstance')
+    def test_call_conversations(self, isinst):
+        isinst.return_value = True
         self.r1.conversations.return_value = list(mock.Mock(scope=scope) for scope in ['s1', 's2'])
         result = relations.relation_call('conversations', 'rel')
         self.assertEqual(result, ['s1', 's2'])
+        isinst.assert_called_once_with(self.r1, relations.RelationBase)


### PR DESCRIPTION
Rather than insisting everything inherits from the fat RelationBase, define a minimal factory type RelationFactory that can be customized and used to build relation instances. The factory defines the two methods required for reactive to acces the relation instances, with the same API as RelationBase. Which makes it backwards compatible since RelationBase and subclasses can serve as their own factories.
