### PR TITLE
Update the first example to reference the import and use the correct method to render a template.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,9 +20,10 @@ and admin password were available, and, if and only if that file was changed,
 the appropriate service would be restarted:
 
 .. code-block:: python
+    from charms.core.templating import render
 
     @when('db.database.available', 'admin-pass')
-    def render_config(pgsql):
+    def render(pgsql):
         render_template('app-config.j2', '/etc/app.conf', {
             'db_conn': pgsql.connection_string(),
             'admin_pass': hookenv.config('admin-pass'),


### PR DESCRIPTION
This fixes the issue raised by #95 , updating the first example to reference and import the correct template `render` function.
