### PR TITLE
Drop Python2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 MANIFEST
 charmhelpers/version.py
 .coverage
-.tox
+.tox/
 .env/
 coverage.xml
 docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.4"
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
+dist: trusty
 language: python
 python:
-  - "3.4"
-install: pip install tox-travis
+  - "3.4"  # Targetting Trusty (Ubuntu 14.04)
+  - "3.5"  # Targetting Xenial (Ubuntu 16.04)
+  - "3.6"  # Targetting the future
+  - "nightly"
+install:
+  - "python3 -c 'import platform;print(platform.linux_distribution())'"
+  - pip install tox-travis
 script: tox

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT=charms
-PYTHON := .tox/py2/bin/python
+PYTHON := .tox/py3/bin/python
 SUITE=unstable
 TESTS=tests/
 VERSION=$(shell cat VERSION)
@@ -32,36 +32,18 @@ userinstall:
 	python setup.py install --user
 
 lint:
-	tox -e lint2,lint3
-
-lint2:
-	tox -e lint2
-
-lint3:
-	tox -e lint3
+	tox -e lint
 
 test:
-	tox
-
-test2:
-	tox -e py2
-
-test3:
 	tox -e py3
 
-ftest2: lint2
-	@echo Starting fast Python 2 tests...
-	.tox/py2/bin/nosetests --attr '!slow' --nologcapture tests/
-
-ftest3: lint3
+ftest: lint
 	@echo Starting fast Python 3 tests...
 	.tox/py3/bin/nosetests --attr '!slow' --nologcapture tests/
 
-ftest: ftest2 ftest3;
-
-docs: lint2
-	.tox/py2/bin/pip install sphinx
-	(cd docs; make html SPHINXBUILD=../.tox/py2/bin/sphinx-build)
+docs: lint
+	.tox/py3/bin/pip install sphinx
+	(cd docs; make html SPHINXBUILD=../.tox/py3/bin/sphinx-build)
 .PHONY: docs
 
 release: test docs

--- a/charms/reactive/cli.py
+++ b/charms/reactive/cli.py
@@ -114,7 +114,7 @@ def mark_invoked(*handler_ids):
         helpers.mark_invoked(handler_id)
 
 
-@cmdline.subcommand()
+@cmdline.subcommand()  # noqa: C901
 def test(*handlers):
     """
     Combined test function to apply one or more tests to multiple handlers.

--- a/charms/reactive/decorators.py
+++ b/charms/reactive/decorators.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
-from six.moves import filter, map
 from functools import wraps, partial
 
 from charmhelpers.core import hookenv

--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -14,12 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import sys
 from inspect import isclass
-
-import six
-from six import with_metaclass
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
@@ -28,7 +24,6 @@ from charms.reactive.bus import get_states
 from charms.reactive.bus import get_state
 from charms.reactive.bus import set_state
 from charms.reactive.bus import remove_state
-from charms.reactive.bus import _load_module
 from charms.reactive.bus import StateList
 
 
@@ -94,7 +89,7 @@ class AutoAccessors(type):
         return __accessor
 
 
-class RelationBase(with_metaclass(AutoAccessors, object)):
+class RelationBase(object, metaclass=AutoAccessors):
     """
     The base class for all relation implementations.
     """
@@ -203,19 +198,7 @@ class RelationBase(with_metaclass(AutoAccessors, object)):
         """
         Find relation implementation based on its role and interface.
         """
-        if six.PY2:
-            # Looks for the first file matching:
-            # ``$CHARM_DIR/hooks/relations/{iface}/{provides,requires,peer}.py``
-            hooks_dir = os.path.join(hookenv.charm_dir(), 'hooks')
-            try:
-                filepath = os.path.join(hooks_dir, 'relations',
-                                        interface, role + '.py')
-                module = _load_module('relations', filepath)
-                return cls._find_subclass(module)
-            except ImportError:
-                return None
-
-        # Already discovered and imported.
+        # The module has already been discovered and imported.
         module = 'relations.{}.{}'.format(interface, role)
         if module in sys.modules:
             return cls._find_subclass(sys.modules[module])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-six>=1.9.0
 PyYAML>=3.10
 charmhelpers>=0.5.0

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,14 @@ with open(version_file) as v:
 SETUP = {
     'name': "charms.reactive",
     'version': VERSION,
-    'author': "Ubuntu Developers",
-    'author_email': "ubuntu-devel-discuss@lists.ubuntu.com",
+    'author': "Charm Reactive Framework Maintainers",
+    'author_email': "juju@lists.ubuntu.com",
     'url': "https://github.com/juju-solutions/charms.reactive",
     'packages': [
         "charms",
         "charms.reactive",
     ],
     'install_requires': [
-        'six',
         'pyaml',
         'charmhelpers>=0.5.0',
     ],

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -621,24 +621,24 @@ class TestReactiveBus(unittest.TestCase):
         ext_path = [root_path, os.path.join(root_path, 'hooks')]
         with extended_sys_path(ext_path):
             top_mod = reactive.bus._load_module(os.path.join(root_path,
-                                                            'reactive'),
+                                                             'reactive'),
                                                 os.path.join(root_path,
-                                                            'reactive',
-                                                            'top_level.py'))
+                                                             'reactive',
+                                                             'top_level.py'))
             sub_mod = reactive.bus._load_module(os.path.join(root_path,
-                                                            'reactive'),
+                                                             'reactive'),
                                                 os.path.join(root_path,
-                                                            'reactive',
-                                                            'nested',
-                                                            'nested.py'))
+                                                             'reactive',
+                                                             'nested',
+                                                             'nested.py'))
             hyp_mod = reactive.bus._load_module(os.path.join(root_path,
-                                                            'hooks',
-                                                            'relations'),
+                                                             'hooks',
+                                                             'relations'),
                                                 os.path.join(root_path,
-                                                            'hooks',
-                                                            'relations',
-                                                            'hyphen-ated',
-                                                            'peer.py'))
+                                                             'hooks',
+                                                             'relations',
+                                                             'hyphen-ated',
+                                                             'peer.py'))
 
         self.assertEqual(top_mod.test_marker, 'top level')
         self.assertEqual(sub_mod.test_marker, 'nested')
@@ -664,8 +664,8 @@ class TestReactiveBus(unittest.TestCase):
         register.assert_called_once_with('reactive/foo')
 
         register.reset_mock()
-        reactive.bus._register_handlers_from_file(
-                'hooks/relations', 'hooks/relations/foo/README.md')
+        reactive.bus._register_handlers_from_file('hooks/relations',
+                                                  'hooks/relations/foo/README.md')
         assert not register.called
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -246,7 +246,7 @@ class TestReactiveDecorators(unittest.TestCase):
 
         @reactive.decorators.only_once
         def test():
-            calls.append(len(calls)+1)
+            calls.append(len(calls) + 1)
 
         handler = reactive.bus.Handler.get(test)
 
@@ -260,7 +260,7 @@ class TestReactiveDecorators(unittest.TestCase):
 
         @reactive.decorators.only_once()
         def test():
-            calls.append(len(calls)+1)
+            calls.append(len(calls) + 1)
 
         handler = reactive.bus.Handler.get(test)
 

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -18,8 +18,6 @@ import sys
 import mock
 import unittest
 
-import six
-
 from charmhelpers.core import hookenv
 from charms.reactive import relations
 
@@ -99,31 +97,9 @@ class TestRelationBase(unittest.TestCase):
         self.assertEqual(res._conversations, ['conv.join'])
         self.assertEqual(res.conversations(), ['conv.join'])
 
-    @unittest.skipUnless(six.PY2, 'Python2 only')
-    @mock.patch.object(relations.hookenv, 'charm_dir')
-    @mock.patch.object(relations.RelationBase, '_find_subclass')
-    @mock.patch.object(relations, '_load_module')
-    def test_find_impl_py2(self, _load_module, find_subclass, charm_dir):
-        charm_dir.return_value = 'charm_dir'
-        _load_module.side_effect = ImportError
-        self.assertIsNone(relations.RelationBase._find_impl('role', 'interface'))
-        _load_module.assert_called_once_with('relations',
-                                             'charm_dir/hooks/relations/interface/role.py')
-        assert not find_subclass.called
-
-        _load_module.reset_mock()
-        _load_module.side_effect = None
-        _load_module.return_value = m1 = mock.Mock(name='m1')
-        find_subclass.return_value = r1 = mock.Mock(name='r1')
-        self.assertIs(relations.RelationBase._find_impl('role', 'interface'), r1)
-        _load_module.assert_called_once_with('relations',
-                                             'charm_dir/hooks/relations/interface/role.py')
-        find_subclass.assert_called_once_with(m1)
-
-    @unittest.skipIf(six.PY2, 'Python3 only')
     @mock.patch.dict('sys.modules')
     @mock.patch.object(relations.RelationBase, '_find_subclass')
-    def test_find_impl_py3(self, find_subclass):
+    def test_find_impl(self, find_subclass):
         self.assertIsNone(relations.RelationBase._find_impl('role',
                                                             'interface'))
         assert not find_subclass.called

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,12 @@ envlist = lint,py3
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
+commands = nosetests {posargs}
 
 [testenv:lint]
 basepython = python3
 envdir = {toxinidir}/.tox/py3
 commands = flake8 {toxinidir}/charms {toxinidir}/tests
-
-[testenv:py3]
-basepython = python3
-commands = nosetests {posargs}
 
 [flake8]
 ignore=

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,28 @@
 [tox]
 skipsdist = True
-envlist = lint{2,3},py{2,3}
+envlist = lint,py3
 
 [testenv]
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 
-[testenv:lint2]
-basepython = python2
-envdir = {toxinidir}/.tox/py2
-commands = flake8 --ignore=E501 {toxinidir}/charms
-
-[testenv:lint3]
+[testenv:lint]
 basepython = python3
 envdir = {toxinidir}/.tox/py3
-commands = flake8 --ignore=E501 {toxinidir}/charms
-
-[testenv:py2]
-basepython = python2
-commands = nosetests {posargs}
+commands = flake8 {toxinidir}/charms {toxinidir}/tests
 
 [testenv:py3]
 basepython = python3
 commands = nosetests {posargs}
+
+[flake8]
+ignore=
+    # This project has lines longer than 79 characters
+    E501,
+    # Lambdas are often more readable, if used carefully
+    E731
+exclude=
+    .git,
+    __pycache__
+max-complexity=10


### PR DESCRIPTION
This branch drops six as a dependency and removes all Python2 specific code paths. charms.reactive becomes a Python3 only project.