### PR TITLE
Do not migrate conversations for hooks that are known to have a limited context

### DIFF
--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -17,23 +17,23 @@
 import os
 import sys
 
-from .bus import set_state  # noqa
-from .bus import remove_state  # noqa
-from .helpers import toggle_state  # noqa
-from .helpers import is_state  # noqa
-from .helpers import all_states  # noqa
-from .relations import scopes  # noqa
-from .relations import RelationBase  # noqa
-from .decorators import hook  # noqa
-from .decorators import when  # noqa
-from .decorators import when_all  # noqa
-from .decorators import when_any  # noqa
-from .decorators import when_not  # noqa
-from .decorators import when_none  # noqa
-from .decorators import when_not_all  # noqa
-from .decorators import not_unless  # noqa
-from .decorators import only_once  # noqa
-from .decorators import when_file_changed  # noqa
+#from .bus import set_state  # noqa
+#from .bus import remove_state  # noqa
+#from .helpers import toggle_state  # noqa
+#from .helpers import is_state  # noqa
+#from .helpers import all_states  # noqa
+#from .relations import scopes  # noqa
+#from .relations import RelationBase  # noqa
+#from .decorators import hook  # noqa
+#from .decorators import when  # noqa
+#from .decorators import when_all  # noqa
+#from .decorators import when_any  # noqa
+#from .decorators import when_not  # noqa
+#from .decorators import when_none  # noqa
+#from .decorators import when_not_all  # noqa
+#from .decorators import not_unless  # noqa
+#from .decorators import only_once  # noqa
+#from .decorators import when_file_changed  # noqa
 
 from . import bus
 from . import relations

--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -53,6 +53,11 @@ def main(relation_name=None):
 
     :param str relation_name: Optional name of the relation which is being handled.
     """
+    # do not migrate conversations for hooks that are known to have a limited context.
+    if hookenv.hook_name() in ['collect-metrics', 'meter-status-changed']:
+        hookenv.log('Reactive main not running for hook %s' % hookenv.hook_name(), level = hookenv.WARNING)
+        return
+    
     hookenv.log('Reactive main running for hook %s' % hookenv.hook_name(), level=hookenv.INFO)
 
     # work-around for https://bugs.launchpad.net/juju-core/+bug/1503039

--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -54,6 +54,7 @@ def main(relation_name=None):
     :param str relation_name: Optional name of the relation which is being handled.
     """
     # do not migrate conversations for hooks that are known to have a limited context.
+    print("about to exit this thing")
     if hookenv.hook_name() in ['collect-metrics', 'meter-status-changed']:
         hookenv.log('Reactive main not running for hook %s' % hookenv.hook_name(), level = hookenv.WARNING)
         return


### PR DESCRIPTION
The ```meter-status-changed``` and ```collect-metrics``` hooks have a limited context, meaning they do not have access to many hook environment commands (e.g. relation-ids). This change prohibits the conversation migration part from running on hooks that are known to have a limited context.