### PR TITLE
Only execute matching hooks in restricted context.

### DIFF
--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -28,6 +28,7 @@ from .flags import remove_state  # noqa  DEPRECATED
 from .flags import toggle_state  # noqa  DEPRECATED
 from .flags import is_state  # noqa  DEPRECATED
 from .flags import all_states  # noqa  DEPRECATED
+from .flags import get_states # noqa  DEPRECATED
 from .flags import any_states  # noqa  DEPRECATED
 from .relations import scopes  # noqa
 from .relations import RelationBase  # noqa
@@ -41,6 +42,8 @@ from .decorators import when_not_all  # noqa
 from .decorators import not_unless  # noqa
 from .decorators import only_once  # noqa
 from .decorators import when_file_changed  # noqa
+from .decorators import collect_metrics # noqa
+from .decorators import meter_status_changed # noqa
 
 from . import bus
 from . import relations
@@ -59,29 +62,36 @@ def main(relation_name=None):
 
     :param str relation_name: Optional name of the relation which is being handled.
     """
-    hookenv.log('Reactive main running for hook %s' % hookenv.hook_name(), level=hookenv.INFO)
+    restricted_mode = hookenv.hook_name() in ['meter-status-changed', 'collect-metrics']
 
+    hookenv.log('Reactive main running for hook %s' % hookenv.hook_name(), level=hookenv.INFO)
+    if restricted_mode:
+        hookenv.log('Restricted mode.', level=hookenv.INFO)
     # work-around for https://bugs.launchpad.net/juju-core/+bug/1503039
     # ensure that external handlers can tell what hook they're running in
     if 'JUJU_HOOK_NAME' not in os.environ:
         os.environ['JUJU_HOOK_NAME'] = os.path.basename(sys.argv[0])
 
-    # update data to be backwards compatible after fix for issue 28
-    relations._migrate_conversations()
+    if not restricted_mode:
+        # update data to be backwards compatible after fix for issue 28
+        relations._migrate_conversations()
 
     def flush_kv():
         if unitdata._KV:
             unitdata._KV.flush()
     hookenv.atexit(flush_kv)
+
     if hookenv.hook_name().endswith('-relation-departed'):
         def depart_conv():
             rel = relations.relation_from_name(hookenv.relation_type())
             rel.conversation().depart()
         hookenv.atexit(depart_conv)
+
     try:
         bus.discover()
-        hookenv._run_atstart()
-        bus.dispatch()
+        if not restricted_mode:  # limit what gets run in restricted mode
+            hookenv._run_atstart()
+        bus.dispatch(restricted=restricted_mode)
     except SystemExit as x:
         if x.code is None or x.code == 0:
             hookenv._run_atexit()

--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -292,9 +292,11 @@ class FlagWatch(object):
         cls._set(data)
 
 
-def dispatch():
+def dispatch(restricted=False):
     """
     Dispatch registered handlers.
+
+    When dispatching in restricted mode, only matching hook handlers are executed.
 
     Handlers are dispatched according to the following rules:
 
@@ -341,6 +343,13 @@ def dispatch():
                     to_invoke = _test(to_invoke)
                     break
         FlagWatch.commit()
+
+    # When in restricted context, only run hooks for that context.
+    if restricted:
+        unitdata.kv().set('reactive.dispatch.phase', 'restricted')
+        hook_handlers = _test(Handler.get_handlers())
+        _invoke(hook_handlers)
+        return
 
     unitdata.kv().set('reactive.dispatch.phase', 'hooks')
     hook_handlers = _test(Handler.get_handlers())

--- a/charms/reactive/decorators.py
+++ b/charms/reactive/decorators.py
@@ -23,6 +23,7 @@ from charms.reactive.bus import _short_action_id
 from charms.reactive.flags import get_flags
 from charms.reactive.relations import relation_from_name, relation_from_state
 from charms.reactive.helpers import _hook
+from charms.reactive.helpers import _restricted_hook
 from charms.reactive.helpers import _when_all
 from charms.reactive.helpers import _when_any
 from charms.reactive.helpers import _when_none
@@ -222,3 +223,25 @@ def only_once(action=None):
     handler.add_predicate(lambda: not was_invoked(action_id))
     handler.add_post_callback(partial(mark_invoked, action_id))
     return action
+
+
+def collect_metrics():
+    """
+    Register the decorated function to run for the collect_metrics hook.
+    """
+    def _register(action):
+        handler = Handler.get(action)
+        handler.add_predicate(partial(_restricted_hook, 'collect-metrics'))
+        return action
+    return _register
+
+
+def meter_status_changed():
+    """
+    Register the decorated function to run when a meter status change has been detected.
+    """
+    def _register(action):
+        handler = Handler.get(action)
+        handler.add_predicate(partial(_restricted_hook, 'meter-status-changed'))
+        return action
+    return _register

--- a/charms/reactive/helpers.py
+++ b/charms/reactive/helpers.py
@@ -149,6 +149,12 @@ def _hook(hook_patterns):
     return dispatch_phase == 'hooks' and any_hook(*hook_patterns)
 
 
+def _restricted_hook(hook_name):
+    current_hook = hookenv.hook_name()
+    dispatch_phase = unitdata.kv().get('reactive.dispatch.phase')
+    return dispatch_phase == 'restricted' and current_hook == hook_name
+
+
 def _when_all(flags):
     dispatch_phase = unitdata.kv().get('reactive.dispatch.phase')
     return dispatch_phase == 'other' and all_flags_set(*flags)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -306,3 +306,35 @@ class TestReactiveDecorators(unittest.TestCase):
         reactive.bus.dispatch()
         assert action3.called
         assert action2.called  # should be called on second iteration
+
+    @mock.patch.object(reactive.decorators, '_restricted_hook')
+    def test_collect_metrics(self, _restricted_hook):
+        _restricted_hook.return_value = True
+        action = mock.Mock(name='action')
+
+        @reactive.collect_metrics()
+        def test_action(*args):
+            action(*args)
+
+        handler = reactive.bus.Handler.get(test_action)
+        assert handler.test()
+        handler.invoke()
+
+        _restricted_hook.assert_called_once_with('collect-metrics')
+        action.assert_called_once()
+
+    @mock.patch.object(reactive.decorators, '_restricted_hook')
+    def test_meter_status_changed(self, _restricted_hook):
+        _restricted_hook.return_value = True
+        action = mock.Mock(name='action')
+
+        @reactive.meter_status_changed()
+        def test_action(*args):
+            action(*args)
+
+        handler = reactive.bus.Handler.get(test_action)
+        assert handler.test()
+        handler.invoke()
+
+        _restricted_hook.assert_called_once_with('meter-status-changed')
+        action.assert_called_once()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -290,3 +290,17 @@ class TestReactiveHelpers(unittest.TestCase):
 
         self.kv.set('reactive.dispatch.phase', 'other')
         assert not test(), 'when_not_all: other; both'
+
+    @mock.patch('charmhelpers.core.hookenv.hook_name')
+    def test_restricted_hook(self, hook_name):
+        self.kv.set('reactive.dispatch.phase', 'restricted')
+        hook_name.return_value = 'meter-status-changed'
+        assert not reactive.helpers._restricted_hook('bar')
+        assert not reactive.helpers._restricted_hook('config-changed')
+        assert reactive.helpers._restricted_hook('meter-status-changed')
+
+        self.kv.set('reactive.dispatch.phase', 'other')
+        hook_name.return_value = 'meter-status-changed'
+        assert not reactive.helpers._restricted_hook('bar')
+        assert not reactive.helpers._restricted_hook('config-changed')
+        assert not reactive.helpers._restricted_hook('meter-status-changed')


### PR DESCRIPTION
Some hooks (collect-metrics, meter-status-changed) are executed in a restricted context. Most hook tools are not available in such contexts, so generic flag handlers should not be executed by charms.reactive. However, we still want layered charms to be able to react to these hooks. A separate main method is added for this purpose.

This method (```main_restricted```) will only execute matching hooks (not state handlers) in a restricted context.