### PR TITLE
Add layer-basic docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ftest: lint
 	.tox/py3/bin/nosetests --attr '!slow' --nologcapture tests/
 
 docs: lint
-	.tox/py3/bin/pip install sphinx sphinx_rtd_theme
+	.tox/py3/bin/pip install sphinx sphinx_rtd_theme recommonmark
 	(cd docs; make html SPHINXBUILD=../.tox/py3/bin/sphinx-build)
 	cd docs/_build/html && zip -r ../docs.zip *
 .PHONY: docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,10 @@
 import sys
 import os
 
+import recommonmark
+from recommonmark.transform import AutoStructify
+
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -42,7 +46,12 @@ extensions = [
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+
+# Add parser for markdon
+source_parsers = {
+   '.md': 'recommonmark.parser.CommonMarkParser',
+}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -273,3 +282,8 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 
 def setup(app):
     app.add_stylesheet('custom.css')
+    app.add_config_value('recommonmark_config', {
+        'url_resolver': lambda url: github_doc_root + url,
+        'auto_toc_tree_section': 'Contents',
+        }, True)
+    app.add_transform(AutoStructify)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -23,8 +23,7 @@ You can find more information about debugging reactive charms in
 Why doesn't my Charm do anything? Why are there no hooks in the ``hooks`` directory?
 ------------------------------------------------------------------------------------
 
-You probably forgot to include
-`layer:basic <https://github.com/juju-solutions/layer-basic>`_ in your
+You probably forgot to include :doc:`layer-basic <layer-basic>` in your
 ``layer.yaml`` file. This layer creates the hook files so that the reactive
 framework starts when a hook runs.
 
@@ -32,28 +31,9 @@ framework starts when a hook runs.
 How can I react to configuration changes?
 -----------------------------------------
 
-`layer:basic <https://github.com/juju-solutions/layer-basic>`_ provides a set
-of easy flags to react to configuration changes. The following flags will be
-automatically managed when you include ``layer:basic`` in your ``layer.yaml`` file.
-
-``layer:basic`` will manage the following flags:
-
-  * ``config.changed``  Any config option has changed from its previous value.
-    This flag is cleared automatically at the end of each hook invocation.
-
-  * ``config.changed.<option>`` A specific config option has changed.
-    ``<option>`` will be replaced by the config option name from ``config.yaml``.
-    This flag is cleared automatically at the end of each hook invocation.
-
-  * ``config.set.<option>`` A specific config option has a True or non-empty
-    value set.  ``<option>`` will be replaced by the config option name from
-    ``config.yaml``. This flag is cleared automatically at the end of each hook
-    invocation.
-
-  * ``config.default.<option>`` A specific config option is set to its
-    default value.  ``option>`` will be replaced by the config option name
-    from ``config.yaml``.  This flag is cleared automatically at the end of
-    each hook invocation.
+The base layer provides :ref:`a set of easy flags <layer-basic/config-flags>`
+to react to configuration changes. These flags will be automatically
+managed when you include ``layer:basic`` in your ``layer.yaml`` file.
 
 How to remove a flag immediately when a config changes?
 ----------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Table of Contents
    :maxdepth: 3
 
    structure
+   layer-basic
    bash-reactive
    faq
    api

--- a/docs/layer-basic.md
+++ b/docs/layer-basic.md
@@ -1,0 +1,294 @@
+# The base layer: layer-basic
+
+<a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Apache 2.0 License"></a>
+
+This is the base layer for all reactive Charms. It provides all of the standard
+Juju hooks and starts the reactive framework when these hooks get executed. It
+also bootstraps the [charm-helpers][] and `charms.reactive` libraries, and all
+of their dependencies for use by the Charm. Check out the
+[code for the basic layer on Github][layer-basic].
+
+
+## Usage
+
+To create a charm layer using this base layer, you need only include it in
+a `layer.yaml` file.
+
+```yaml
+includes: ['layer:basic']
+```
+
+This will fetch this layer from [interfaces.juju.solutions][] and incorporate
+it into your charm layer. You can then add handlers under the `reactive/`
+directory. Note that **any** file under `reactive/` will be expected to
+contain handlers, whether as Python decorated functions or [executables][non-python]
+using the [external handler protocol][external handler protocol].
+
+
+## Hooks
+
+This layer provides hooks so that the reactive framework gets started when these
+hooks run, and so that other layers can react to these hooks using the
+decorators of the [charms.reactive][] library:
+
+  * `config-changed`
+  * `install`
+  * `leader-elected`
+  * `leader-settings-changed`
+  * `start`
+  * `stop`
+  * `upgrade-charm`
+  * `update-status`
+
+Other hooks are not implemented at this time. A new layer can implement other
+hooks such as `storage` in their own layer by putting them in the `hooks`
+directory.
+
+```eval_rst
+.. note:: Because ``update-status`` is invoked every 5 minutes, you should take
+   care to ensure that your reactive handlers only invoke expensive operations
+   when absolutely necessary.  It is recommended that you use helpers like
+   :func:`@when_file_changed <charms.reactive.decorators.when_file_changed>`,
+   and :func:`@data_changed <charms.reactive.helpers.data_changed>` to ensure
+   that handlers run only when necessary.
+```
+
+
+```eval_rst
+.. _layer-basic/config-flags:
+```
+## Reactive flags for Charm config
+
+This layer will set the following flags:
+
+  * **`config.changed`**  Any config option has changed from its previous value.
+    This flag is cleared automatically at the end of each hook invocation.
+
+  * **`config.changed.<option>`** A specific config option has changed.
+    **`<option>`** will be replaced by the config option name from `config.yaml`.
+    This flag is cleared automatically at the end of each hook invocation.
+
+  * **`config.set.<option>`** A specific config option has a True or non-empty
+    value set.  **`<option>`** will be replaced by the config option name from
+    `config.yaml`. This flag is cleared automatically at the end of each hook
+    invocation.
+
+  * **`config.default.<option>`** A specific config option is set to its
+    default value.  **`<option>`** will be replaced by the config option name
+    from `config.yaml`. This flag is cleared automatically at the end of
+    each hook invocation.
+
+An example using the config flags would be:
+
+```python
+@when('config.changed.my-opt')
+def my_opt_changed():
+    update_config()
+    restart_service()
+```
+
+
+```eval_rst
+.. _layer-basic/layer-config:
+```
+## Layer Configuration
+
+This layer supports the following options, which can be set in `layer.yaml`:
+
+  * **packages**  A list of system packages to be installed before the reactive
+    handlers are invoked.
+    ```eval_rst
+    .. note:: The ``packages`` layer option is intended for **charm** dependencies only.
+       That is, for libraries and applications that the charm code itself needs to
+       do its job of deploying and configuring the payload. If the payload (the
+       application you're deploying) itself has dependencies, those should be
+       handled separately, by your Charm using for example the
+       `Apt layer <https://github.com/stub42/layer-apt>`_
+    ```
+
+  * **use_venv**  If set to true, the charm dependencies from the various
+    layers' `wheelhouse.txt` files will be installed in a Python virtualenv
+    located at `$JUJU_CHARM_DIR/../.venv`.  This keeps charm dependencies from
+    conflicting with payload dependencies, but you must take care to preserve
+    the environment and interpreter if using `execl` or `subprocess`.
+
+  * **include_system_packages**  If set to true and using a venv, include
+    the `--system-site-packages` options to make system Python libraries
+    visible within the venv.
+
+An example `layer.yaml` using these options might be:
+
+```yaml
+includes: ['layer:basic']
+options:
+  basic:
+    packages: ['git']
+    use_venv: true
+    include_system_packages: true
+```
+
+
+```eval_rst
+.. _layer-basic/wheelhouse.txt:
+```
+## Wheelhouse.txt for Charm Python dependencies
+
+`layer-basic` provides two methods to install dependencies of your charm code:
+`wheelhouse.txt` for python dependencies and the `packages` layer option for
+apt dependencies.
+
+
+Each layer can include a `wheelhouse.txt` file with Python requirement lines.
+*The format of this file is the same as pip's [`requirements.txt`][] file.*
+For example, this layer's `wheelhouse.txt` includes:
+
+```
+pip>=7.0.0,<8.0.0
+charmhelpers>=0.4.0,<1.0.0
+charms.reactive>=0.1.0,<2.0.0
+```
+
+All of these dependencies from each layer will be fetched (and updated) at build
+time and will be automatically installed by this base layer **before any
+reactive handlers are run.**
+
+See [PyPI][pypi charms.X] for packages under the `charms.` namespace which might
+be useful for your charm. See the `packages` layer option of this layer for
+installing ``apt`` dependencies of your Charm code.
+
+```eval_rst
+.. note:: The ``wheelhouse.yaml`` are intended for **charm** dependencies only.
+   That is, for libraries and applications that the charm code itself needs to
+   do its job of deploying and configuring the payload. If the payload (the
+   application you're deploying) itself has dependencies, those should be
+   handled separately.
+```
+
+
+## Exec.d Support
+
+It is often necessary to configure and reconfigure machines
+after provisioning, but before attempting to run the charm.
+Common examples are specialized network configuration, enabling
+of custom hardware, non-standard disk partitioning and filesystems,
+adding secrets and keys required for using a secured network.
+
+The reactive framework's base layer invokes this mechanism as
+early as possible, before any network access is made or dependencies
+unpacked or non-standard modules imported (including the charms.reactive
+framework itself).
+
+Operators needing to use this functionality may branch a charm and
+create an exec.d directory in it. The exec.d directory in turn contains
+one or more subdirectories, each of which contains an executable called
+charm-pre-install and any other required resources. The charm-pre-install
+executables are run, and if successful, state saved so they will not be
+run again.
+
+```
+$JUJU_CHARM_DIR/exec.d/mynamespace/charm-pre-install
+```
+
+An alternative to branching a charm is to compose a new charm that contains
+the exec.d directory, using the original charm as a layer,
+
+A charm author could also abuse this mechanism to modify the charm
+environment in unusual ways, but for most purposes it is saner to use
+`charmhelpers.core.hookenv.atstart()`.
+
+
+## General layer info
+
+
+### Layer Namespace
+
+Each layer has a reserved section in the `charms.layer.` Python package namespace,
+which it can populate by including a `lib/charms/layer/<layer-name>.py` file or
+by placing files under `lib/charms/layer/<layer-name>/`.  (If the layer name
+includes hyphens, replace them with underscores.)  These can be helpers that the
+layer uses internally, or it can expose classes or functions to be used by other
+layers to interact with that layer.
+
+For example, a layer named `foo` could include a `lib/charms/layer/foo.py` file
+with some helper functions that other layers could access using:
+
+```python
+from charms.layer.foo import my_helper
+```
+
+
+### Layer Options
+
+Any layer can define options in its `layer.yaml`.  Those options can then be set
+by other layers to change the behavior of your layer.  The options are defined
+using [jsonschema][], which is the same way that [action paramters][] are defined.
+
+For example, the `foo` layer could include the following option definitons:
+
+```yaml
+includes: ['layer:basic']
+defines:  # define some options for this layer (the layer "foo")
+  enable-bar:  # define an "enable-bar" option for this layer
+    description: If true, enable support for "bar".
+    type: boolean
+    default: false
+```
+
+A layer using `foo` could then set it:
+
+```yaml
+includes: ['layer:foo']
+options:
+  foo:  # setting options for the "foo" layer
+    enable-bar: true  # set the "enable-bar" option to true
+```
+
+The `foo` layer can then use the `charms.layer.options` helper to load the values
+for the options that it defined.  For example:
+
+```python
+from charms import layer
+
+@when('flag')
+def do_thing():
+  layer_opts = layer.options('foo')  # load all of the options for the "foo" layer
+  if layer_opts['enable-bar']:  # check the value of the "enable-bar" option
+      hookenv.log("Bar is enabled")
+```
+
+You can also access layer options in other handlers, such as Bash, using
+the command-line interface:
+
+```bash
+. charms.reactive.sh
+
+@when 'flag'
+function do_thing() {
+    if layer_option foo enable-bar; then
+        juju-log "Bar is enabled"
+        juju-log "bar-value is: $(layer_option foo bar-value)"
+    fi
+}
+
+reactive_handler_main
+```
+
+Note that options of type `boolean` will set the exit code, while other types
+will be printed out.
+
+
+[charm-helpers]: https://pythonhosted.org/charmhelpers/
+[charms.reactive]: https://charmsreactive.readthedocs.io/en/latest/
+[interfaces.juju.solutions]: http://interfaces.juju.solutions/
+[non-python]: https://charmsreactive.readthedocs.io/en/latest/bash-reactive.html
+[external handler protocol]: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.bus.html#charms.reactive.bus.ExternalHandler
+[jsonschema]: http://json-schema.org/
+[action paramters]: https://jujucharms.com/docs/stable/authors-charm-actions
+[pypi charms.X]: https://pypi.python.org/pypi?%3Aaction=search&term=charms.&submit=search
+[`requirements.txt`]: https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+[layer-basic]: https://github.com/juju-solutions/layer-basic
+
+<!---
+Hard-coding links to other charms.reactive docs is currently required.
+https://github.com/rtfd/recommonmark/issues/8
+-->

--- a/docs/structure.rst
+++ b/docs/structure.rst
@@ -117,14 +117,13 @@ will then be merged onto the one provided by the base layer, and both sets of
 actions will be available.
 
 
-`layer:basic`_ is a useful base layer:
+:doc:`layer:basic <layer-basic>` is a useful base layer:
 
  - It provides hooks for other layers to react to such as ``install``,
    ``config-changed``, ``upgrade-charm``, and ``update-status``.
- - It provides a `set of useful flags to react to changing config <https://github.com/juju-solutions/layer-basic#reactive-states>`_.
- - You can tell it to `install dependencies of your handlers <https://github.com/juju-solutions/layer-basic#layer-configuration>`_.
+ - It provides a :ref:`set of useful flags to react to changing config <layer-basic/config-flags>`.
+ - You can tell it to install :ref:`python <layer-basic/wheelhouse.txt>` and :ref:`apt <layer-basic/layer-config>` dependencies of your handlers.
 
-.. _`layer:basic`: https://github.com/juju-solutions/layer-basic/blob/master/README.md
 
 Interface Layers
 ----------------


### PR DESCRIPTION
This PR adds the layer-basic docs to the charms.reactive docs. This PR is accompanied by the PR in layer-basic to remove the docs there: https://github.com/juju-solutions/layer-basic/pull/103.

I opted to use `recommonmark`, this allows you to use markdown files in sphinx docs, this way we don't need to rewrite markdown -> sphinx.

Fixes: https://github.com/juju-solutions/charms.reactive/issues/142