### PR TITLE
Add deprecated placeholder for RelationBase.from_state

### DIFF
--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -55,7 +55,7 @@ def endpoint_from_name(endpoint_name):
 
 def relation_from_name(relation_name):
     """
-    .. deprecated:: 0.5.0
+    .. deprecated:: 0.6.0
        Alias for :func:`endpoint_from_name`
     """
     return endpoint_from_name(relation_name)
@@ -86,7 +86,7 @@ def endpoint_from_flag(flag):
 
 def relation_from_flag(flag):
     """
-    .. deprecated:: 0.5.0
+    .. deprecated:: 0.6.0
        Alias for :func:`endpoint_from_flag`
     """
     return endpoint_from_flag(flag)
@@ -329,10 +329,21 @@ class RelationBase(RelationFactory, metaclass=AutoAccessors):
         return self._relation_name
 
     @classmethod
+    def from_state(cls, state):
+        """
+        .. deprecated:: 0.6.0
+           use :func:`endpoint_from_flag` instead
+        """
+        return cls.from_flag(state)
+
+    @classmethod
     def from_flag(cls, flag):
         """
         Find relation implementation in the current charm, based on the
-        name of an active state.
+        name of an active flag.
+
+        You should not use this method directly.
+        Use :func:`endpoint_from_flag` instead.
         """
         value = _get_flag_value(flag)
         if value is None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 ^^^^^
 
 * Endpoint base for easier interface layers (#123)
+* Public API is now only documented via the top level charms.reactive namespace.
+  The internal organization of the library is not part of the public API.
 * added layer-basic docs (#144)
 * Fix test error from juju-wait snap (#143)
 * PR for design discussions of charms.reactive 2.0 (#130)
@@ -15,6 +17,10 @@
 * fixed test, order doesn't matter (#131)
 * Added FAQ section to docs (#129)
 * point travis badge to master branch, removed links to old repos. (#127)
+* Deprecations:
+  * relation_from_name (renamed to endpoint_from_name)
+  * relation_from_flag (renamed to endpoint_from_flag)
+  * RelationBase.from_state (use endpoint_from_flag instead)
 
 0.5.0
 ^^^^^
@@ -24,6 +30,19 @@
 * Only execute matching hooks in restricted context. (#119)
 * Rename "state" to "flag" and deprecate "state" name (#112)
 * Allow pluggable alternatives to RelationBase (#111)
+* Deprecations:
+  * State
+  * StateList
+  * set_state (renamed to set_flag)
+  * remove_state (renamed to clear_flag)
+  * toggle_state (renamed to toggle_flag)
+  * is_state (renamed to is_flag_set)
+  * all_states (renamed to all_flags)
+  * any_states (renamed to any_flags)
+  * get_states (renamed to get_flags)
+  * get_state
+  * only_once
+  * relation_from_state (renamed to relation_from_flag)
 
 0.4.7
 ^^^^^


### PR DESCRIPTION
For backwards compatibility, in case anyone is using it.

Added info about all deprecations to the changelog to make them more visible.