### PR TITLE
Separate departed units from joined in Endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,20 @@ language: python
 python:
   - "3.5"
 env:
-  - SNAP_CMD="sudo snap install juju --classic --stable"
-  - SNAP_CMD="sudo snap install juju --classic --edge"
+  - SNAP_CHANNEL="stable"
+  - SNAP_CHANNEL="edge"
 before_install:
-  - sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable -y
-  - sudo apt-get update -q
-  - sudo apt-get install lxd snapd pwgen -y
-  - sudo usermod -a -G lxd $USER
-  - sudo service lxd start || true
-  - sudo lxd init --auto
+  - sudo apt-get install snapd pwgen -y
+  - sudo apt-get remove -qy lxd lxd-client
 install:
   - pip install tox-travis
-  - (eval "$SNAP_CMD")
-  - sudo snap install charm --edge
-  - sudo snap install --classic juju-wait
+  - sudo snap install lxd --$SNAP_CHANNEL
+  - sudo snap install juju --classic --$SNAP_CHANNEL
+  - sudo snap install charm --$SNAP_CHANNEL
+  - sudo snap install --classic juju-wait --$SNAP_CHANNEL
 before_script:
+  - sudo addgroup lxd || true
+  - sudo usermod -a -G lxd $USER
   - sudo -E sudo -u $USER -E bash -c "/snap/bin/juju bootstrap localhost test"
 script:
   - tox -e lint,py35

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ ftest: lint
 	.tox/py3/bin/nosetests --attr '!slow' --nologcapture tests/
 
 docs: lint
-	.tox/py3/bin/pip install sphinx sphinx_rtd_theme recommonmark
+	.tox/py3/bin/pip install 'sphinx>=1.7b2' sphinx_rtd_theme recommonmark
 	(cd docs; make html SPHINXBUILD=../.tox/py3/bin/sphinx-build)
 	cd docs/_build/html && zip -r ../docs.zip *
 .PHONY: docs

--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -164,7 +164,7 @@ class Endpoint(RelationFactory):
         Collection of :class:`Relation` instances that were previously
         established for this :class:`Endpoint` but which are no longer.
 
-        Like :prop:`.relations`, this is a :class:`KeyList`.  However, it is
+        Like :attr:`relations`, this is a :class:`KeyList`.  However, it is
         also both persistent and mutable.  Once a broken relation has been
         handled, however is appropriate for the charm, it can be deleted from
         this collection.  A broken relation will eventually be cleaned up
@@ -279,7 +279,7 @@ class Endpoint(RelationFactory):
         be kept until they are explicitly removed, to allow for reasonable
         cleanup of units that have left.
 
-        Once a unit is departed, it will no longer show up in :prop:`.all_units`.
+        Once a unit is departed, it will no longer show up in :attr:`all_units`.
         Note that units are considered departed as soon as the departed hook
         is entered, which differs slightly from how the Juju primitives behave
         (departing units are still returned from ``related-units`` until after
@@ -376,7 +376,7 @@ class Relation:
         be kept until they are explicitly removed to allow for reasonable
         cleanup of units that have left.
 
-        Once a unit is departed, it will no longer show up in :prop:`.units`.
+        Once a unit is departed, it will no longer show up in :attr:`units`.
         Note that units are considered departed as soon as the departed hook
         is entered, which differs slightly from how the Juju primitives behave
         (departing units are still returned from ``related-units`` until after

--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -306,6 +306,13 @@ class Relation:
         return self._endpoint_name
 
     @property
+    def endpoint(self):
+        """
+        This relation's :class:`Endpoint` instance.
+        """
+        return Endpoint.from_name(self.endpoint_name)
+
+    @property
     def application_name(self):
         """
         The name of the remote application for this relation, or ``None``.

--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -46,14 +46,19 @@ class Endpoint(RelationFactory):
     Four flags are automatically managed for each endpoint. Endpoint handlers
     can react to these flags using the :class:`~charms.reactive.decorators`.
 
-      * ``endpoint.{endpoint_name}.joined`` When the endpoint is :meth:`joined`.
-      * ``endpoint.{endpoint_name}.changed`` When any relation data has changed.
-      * ``endpoint.{endpoint_name}.changed.{field}`` When a specific field has changed.
-      * ``endpoint.{endpoint_name}.departed`` When a remote unit is leaving.
+      * ``endpoint.{endpoint_name}.joined`` is set when the endpoint is
+        :meth:`joined`: when the first remote unit from any relationship
+        connected to this endpoint joins. It is cleared when the last unit
+        from all relationships connected to this endpoint departs.
+      * ``endpoint.{endpoint_name}.changed`` when any relation data has
+        changed. It isn't automatically cleared.
+      * ``endpoint.{endpoint_name}.changed.{field}`` when a specific field
+        has changed. It isn't automatically cleared.
+      * ``endpoint.{endpoint_name}.departed`` when a remote unit is leaving.
+         It isn't automatically cleared.
 
-    The ``joined`` flag will be automatically removed if all remote units leave
-    all relations, but the others must be manually removed by the interface
-    layer.
+    For the flags that are not automatically cleared, it is up to the interface
+    author to clear the flag when it is "handled".
 
     These flags should only be used by the decorators of the endpoint handlers.
     While it is possible to use them with any decorators in any layer, these

--- a/docs/charms.reactive.relations.rst
+++ b/docs/charms.reactive.relations.rst
@@ -15,6 +15,7 @@ base for writing interface layers.  Eventually, this should be moved in to `char
 
 .. automodule:: charms.reactive.endpoints
     :members:
+    :ignore-module-all:
     :undoc-members:
     :show-inheritance:
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -105,20 +105,14 @@ class TestEndpoint(unittest.TestCase):
         self.sysm_p = mock.patch.dict(sys.modules)
         self.sysm_p.start()
 
-        self.kv.set('reactive.endpoints.broken.test-endpoint', [
-            'test-endpoint:2',
-            'test-endpoint:3',
-        ])
-
-        self.kv.set('reactive.endpoints.departed.test-endpoint:0', [
+        self.kv.set('reactive.endpoints.departed.test-endpoint', [
             {
+                'relation': 'test-endpoint:1',
                 'unit_name': 'unit/3',
                 'data': {'departed': 'true'},
             },
-        ])
-
-        self.kv.set('reactive.endpoints.departed.test-endpoint:2', [
             {
+                'relation': 'test-endpoint:2',
                 'unit_name': 'unit/4',
                 'data': {'departed': 'true'},
             },
@@ -221,69 +215,87 @@ class TestEndpoint(unittest.TestCase):
         tep = Endpoint.from_name('test-endpoint')
 
         self.assertEqual(len(tep.relations), 2)
-        self.assertEqual(len(tep.relations[0].units), 2)
-        self.assertEqual(len(tep.relations[1].units), 2)
+        self.assertEqual(len(tep.relations[0].joined_units), 2)
+        self.assertEqual(len(tep.relations[1].joined_units), 2)
         self.assertEqual(tep.relations['test-endpoint:0'].relation_id, 'test-endpoint:0')
-        self.assertEqual(len(tep.all_units), 4)
-        self.assertEqual([u.unit_name for r in tep.relations for u in r.units],
+        self.assertEqual(len(tep.all_joined_units), 4)
+        self.assertEqual([u.unit_name for r in tep.relations for u in r.joined_units],
                          ['unit/0', 'unit/1', 'unit/0', 'unit/1'])
-        self.assertEqual([u.unit_name for u in tep.all_units],
+        self.assertEqual([u.unit_name for u in tep.all_joined_units],
                          ['unit/0', 'unit/1', 'unit/0', 'unit/1'])
-        self.assertEqual(tep.relations[0].units['unit/1'].unit_name, 'unit/1')
+        self.assertEqual(tep.relations[0].joined_units['unit/1'].unit_name, 'unit/1')
         self.assertEqual(tep.relations[0].relation_id, 'test-endpoint:0')
         self.assertEqual(tep.relations[0].endpoint_name, 'test-endpoint')
         self.assertEqual(tep.relations[0].application_name, 'unit')
-        self.assertEqual(tep.relations[0].units[0].unit_name, 'unit/0')
-        self.assertEqual(tep.all_units.keys(), ['unit/0', 'unit/1', 'unit/0', 'unit/1'])
-        self.assertEqual(tep.relations[0].units.keys(), ['unit/0', 'unit/1'])
+        self.assertEqual(tep.relations[0].joined_units[0].unit_name, 'unit/0')
+        self.assertEqual(tep.all_joined_units.keys(), ['unit/0', 'unit/1', 'unit/0', 'unit/1'])
+        self.assertEqual(tep.relations[0].joined_units.keys(), ['unit/0', 'unit/1'])
         self.assertEqual(tep.relations.keys(), ['test-endpoint:0', 'test-endpoint:1'])
+        self.assertIs(tep.all_units, tep.all_joined_units)  # deprecated
+        self.assertIs(tep.relations[0].units, tep.relations[0].joined_units)  # deprecated
 
     def test_departed(self):
+        # clean up some units for this test
+        del self.relations['test-endpoint'][0]['unit/1']
+        del self.relations['test-endpoint'][1]['unit/0']
+        # add unit/2 as joined
+        self.relations['test-endpoint'][0]['unit/2'] = {'departed': 'yes'}
+        # but set current hook as unit/2 departing
         self.hook_name = 'test-endpoint-relation-departed'
         self.relation_id = 'test-endpoint:0'
-        self.remote_unit = 'unit/1'
-        del self.relations['test-endpoint'][1]['unit/0']
-        self.relations['test-endpoint'][0]['unit/1'] = {'departed': 'yes'}
+        self.remote_unit = 'unit/2'
         Endpoint._startup()
         tep = Endpoint.from_name('test-endpoint')
 
         self.assertCountEqual(tep.relations.keys(), ['test-endpoint:0', 'test-endpoint:1'])
-        self.assertCountEqual(tep.broken_relations.keys(), ['test-endpoint:2'])
-        self.assertCountEqual(tep.all_departed_units.keys(), ['unit/1', 'unit/3', 'unit/4'])
-        self.assertCountEqual(tep.relations['test-endpoint:0'].units.keys(), ['unit/0'])
-        self.assertCountEqual(tep.relations['test-endpoint:1'].units.keys(), ['unit/1'])
-        self.assertCountEqual(tep.relations['test-endpoint:0'].departed_units.keys(), ['unit/1', 'unit/3'])
-        self.assertCountEqual(tep.relations['test-endpoint:1'].departed_units.keys(), [])
-        self.assertCountEqual(tep.broken_relations['test-endpoint:2'].departed_units.keys(), ['unit/4'])
-        self.assertIs(tep.relations[0].departed_units[0].received['departed'], True)
-        self.assertEqual(tep.relations[0].departed_units[1].received_raw['departed'], 'yes')
+        self.assertCountEqual(tep.all_joined_units.keys(), ['unit/0', 'unit/1'])
+        self.assertCountEqual(tep.all_departed_units.keys(), ['unit/2', 'unit/3', 'unit/4'])
+        self.assertEqual(tep.all_departed_units['unit/2'].received_raw['departed'], 'yes')
+        self.assertIs(tep.all_departed_units['unit/3'].received['departed'], True)
 
-        self.assertCountEqual(self.kv.get('reactive.endpoints.departed.test-endpoint:0'), [
+        self.assertCountEqual(self.kv.get('reactive.endpoints.departed.test-endpoint'), [
             {
-                'unit_name': 'unit/1',
+                'relation': 'test-endpoint:0',
+                'unit_name': 'unit/2',
                 'data': {
                     'departed': 'yes',
                 },
             },
             {
+                'relation': 'test-endpoint:1',
                 'unit_name': 'unit/3',
                 'data': {
                     'departed': 'true',
                 },
             },
-        ])
-        del tep.relations[0].departed_units['unit/3']
-        self.assertEqual(self.kv.get('reactive.endpoints.departed.test-endpoint:0'), [
             {
-                'unit_name': 'unit/1',
+                'relation': 'test-endpoint:2',
+                'unit_name': 'unit/4',
+                'data': {
+                    'departed': 'true',
+                },
+            },
+        ])
+        del tep.all_departed_units['unit/3']
+        self.assertCountEqual(self.kv.get('reactive.endpoints.departed.test-endpoint'), [
+            {
+                'relation': 'test-endpoint:0',
+                'unit_name': 'unit/2',
                 'data': {
                     'departed': 'yes',
                 },
             },
+            {
+                'relation': 'test-endpoint:2',
+                'unit_name': 'unit/4',
+                'data': {
+                    'departed': 'true',
+                },
+            },
         ])
+        del tep.all_departed_units['unit/2']
         del tep.all_departed_units['unit/4']
-        self.assertIsNone(self.kv.get('reactive.endpoints.departed.test-endpoint:2'))
-        self.assertCountEqual(tep.all_departed_units.keys(), ['unit/1'])
+        self.assertIsNone(self.kv.get('reactive.endpoints.departed.test-endpoint'))
 
         # test relation moves to broken during last departed hook
         self.relation_id = 'test-endpoint:1'
@@ -291,60 +303,59 @@ class TestEndpoint(unittest.TestCase):
         Endpoint._startup()
         tep = Endpoint.from_name('test-endpoint')
         self.assertEqual(tep.relations.keys(), ['test-endpoint:0'])
-        self.assertEqual(tep.broken_relations.keys(), ['test-endpoint:1'])
 
     def test_receive(self):
         Endpoint._startup()
         tep = Endpoint.from_name('test-endpoint')
 
-        self.assertEqual(tep.all_units.received_raw, {'foo': 'yes',
-                                                      'bar': '[1, 2]'})
-        self.assertEqual(tep.all_units.received, {'foo': 'yes',
-                                                  'bar': [1, 2]})
-        self.assertEqual(tep.relations[0].units.received_raw, {'foo': 'yes'})
-        self.assertEqual(tep.relations[1].units.received_raw, {'foo': 'no',
-                                                               'bar': '[1, 2]'})
-        self.assertEqual(tep.relations[0].units.received, {'foo': 'yes'})
-        self.assertEqual(tep.relations[1].units.received, {'foo': 'no',
-                                                           'bar': [1, 2]})
-        self.assertEqual(tep.relations[0].units[0].received_raw, {'foo': 'yes'})
-        self.assertEqual(tep.relations[0].units[1].received_raw, {})
-        self.assertEqual(tep.relations[1].units[0].received_raw, {'bar': '[1, 2]'})
-        self.assertEqual(tep.relations[1].units[1].received_raw, {'foo': 'no'})
-        self.assertEqual(tep.relations[0].units[0].received, {'foo': 'yes'})
-        self.assertEqual(tep.relations[0].units[1].received, {})
-        self.assertEqual(tep.relations[1].units[0].received, {'bar': [1, 2]})
-        self.assertEqual(tep.relations[1].units[1].received, {'foo': 'no'})
+        self.assertEqual(tep.all_joined_units.received_raw, {'foo': 'yes',
+                                                             'bar': '[1, 2]'})
+        self.assertEqual(tep.all_joined_units.received, {'foo': 'yes',
+                                                         'bar': [1, 2]})
+        self.assertEqual(tep.relations[0].joined_units.received_raw, {'foo': 'yes'})
+        self.assertEqual(tep.relations[1].joined_units.received_raw, {'foo': 'no',
+                                                                      'bar': '[1, 2]'})
+        self.assertEqual(tep.relations[0].joined_units.received, {'foo': 'yes'})
+        self.assertEqual(tep.relations[1].joined_units.received, {'foo': 'no',
+                                                                  'bar': [1, 2]})
+        self.assertEqual(tep.relations[0].joined_units[0].received_raw, {'foo': 'yes'})
+        self.assertEqual(tep.relations[0].joined_units[1].received_raw, {})
+        self.assertEqual(tep.relations[1].joined_units[0].received_raw, {'bar': '[1, 2]'})
+        self.assertEqual(tep.relations[1].joined_units[1].received_raw, {'foo': 'no'})
+        self.assertEqual(tep.relations[0].joined_units[0].received, {'foo': 'yes'})
+        self.assertEqual(tep.relations[0].joined_units[1].received, {})
+        self.assertEqual(tep.relations[1].joined_units[0].received, {'bar': [1, 2]})
+        self.assertEqual(tep.relations[1].joined_units[1].received, {'foo': 'no'})
 
-        self.assertEqual(tep.all_units.received_raw['bar'], '[1, 2]')
-        self.assertEqual(tep.all_units.received_raw.get('bar'), '[1, 2]')
-        self.assertEqual(tep.all_units.received['bar'], [1, 2])
-        self.assertEqual(tep.all_units.received.get('bar'), [1, 2])
-        self.assertIsNone(tep.all_units.received_raw['none'])
-        self.assertEqual(tep.all_units.received_raw.get('none', 'default'), 'default')
-        self.assertIsNone(tep.all_units.received['none'])
-        self.assertEqual(tep.all_units.received.get('none', 'default'), 'default')
+        self.assertEqual(tep.all_joined_units.received_raw['bar'], '[1, 2]')
+        self.assertEqual(tep.all_joined_units.received_raw.get('bar'), '[1, 2]')
+        self.assertEqual(tep.all_joined_units.received['bar'], [1, 2])
+        self.assertEqual(tep.all_joined_units.received.get('bar'), [1, 2])
+        self.assertIsNone(tep.all_joined_units.received_raw['none'])
+        self.assertEqual(tep.all_joined_units.received_raw.get('none', 'default'), 'default')
+        self.assertIsNone(tep.all_joined_units.received['none'])
+        self.assertEqual(tep.all_joined_units.received.get('none', 'default'), 'default')
 
-        assert not tep.all_units.received_raw.writeable
-        assert not tep.all_units.received.writeable
-
-        with self.assertRaises(ValueError):
-            tep.all_units.received_raw['foo'] = 'nope'
+        assert not tep.all_joined_units.received_raw.writeable
+        assert not tep.all_joined_units.received.writeable
 
         with self.assertRaises(ValueError):
-            tep.relations[0].units.received_raw['foo'] = 'nope'
+            tep.all_joined_units.received_raw['foo'] = 'nope'
 
         with self.assertRaises(ValueError):
-            tep.relations[0].units[0].received_raw['foo'] = 'nope'
+            tep.relations[0].joined_units.received_raw['foo'] = 'nope'
 
         with self.assertRaises(ValueError):
-            tep.all_units.received['foo'] = 'nope'
+            tep.relations[0].joined_units[0].received_raw['foo'] = 'nope'
 
         with self.assertRaises(ValueError):
-            tep.relations[0].units.received['foo'] = 'nope'
+            tep.all_joined_units.received['foo'] = 'nope'
 
         with self.assertRaises(ValueError):
-            tep.relations[0].units[0].received['foo'] = 'nope'
+            tep.relations[0].joined_units.received['foo'] = 'nope'
+
+        with self.assertRaises(ValueError):
+            tep.relations[0].joined_units[0].received['foo'] = 'nope'
 
     def test_to_publish(self):
         Endpoint._startup()


### PR DESCRIPTION
This fixes #151 by adding a `departed_units` collection which doesn't count toward joined units when determining if the endpoint is still considered joined.

**Edit:** Also fixes #152