### PR TITLE
Fix setdefault on Endpoint data collections

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -748,6 +748,11 @@ class UnitDataView(UserDict):
         self._modified = True
         self.data[key] = value
 
+    def setdefault(self, key, value):
+        if key not in self:
+            self[key] = value
+        return self[key]
+
 
 class JSONUnitDataView(UserDict):
     """
@@ -807,6 +812,11 @@ class JSONUnitDataView(UserDict):
 
     def __setitem__(self, key, value):
         self.raw_data[key] = json.dumps(value, sort_keys=True)
+
+    def setdefault(self, key, value):
+        if key not in self:
+            self[key] = value
+        return self[key]
 
 
 hookenv.atstart(Endpoint._startup)

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -383,6 +383,10 @@ class TestEndpoint(unittest.TestCase):
         rel.to_publish.update({'key': {'new': 'new'}})
         self.assertEqual(rel.to_publish_raw, {'key': '{"new": "new"}'})
 
+        assert isinstance(rel.to_publish.get('foo', {}), dict)
+        assert isinstance(rel.to_publish.setdefault('foo', {}), dict)
+        assert isinstance(rel.to_publish['foo'], dict)
+
     def test_handlers(self):
         Handler._HANDLERS = {k: h for k, h in Handler._HANDLERS.items()
                              if hasattr(h, '_action') and

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -383,9 +383,18 @@ class TestEndpoint(unittest.TestCase):
         rel.to_publish.update({'key': {'new': 'new'}})
         self.assertEqual(rel.to_publish_raw, {'key': '{"new": "new"}'})
 
-        assert isinstance(rel.to_publish.get('foo', {}), dict)
-        assert isinstance(rel.to_publish.setdefault('foo', {}), dict)
-        assert isinstance(rel.to_publish['foo'], dict)
+        assert 'foo' not in rel.to_publish
+        assert rel.to_publish.get('foo', 'one') == 'one'
+        assert 'foo' not in rel.to_publish
+        assert rel.to_publish.setdefault('foo', 'two') == 'two'
+        assert 'foo' in rel.to_publish
+        assert rel.to_publish['foo'] == 'two'
+        del rel.to_publish['foo']
+        assert 'foo' not in rel.to_publish
+        with self.assertRaises(KeyError):
+            del rel.to_publish['foo']
+        assert 'foo' not in rel.to_publish
+        assert rel.to_publish['foo'] is None
 
     def test_handlers(self):
         Handler._HANDLERS = {k: h for k, h in Handler._HANDLERS.items()


### PR DESCRIPTION
`UserDict`'s implementation of `setdefault` doesn't work with the `None` default value in our data collections, leading to `setdefault` always returning `None` and never updating the collection.