### PR TITLE
Remove state when its value is "None"

### DIFF
--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -702,6 +702,7 @@ class Conversation(object):
         state = state.format(relation_name=self.relation_name)
         value = _get_flag_value(state)
         if not value:
+            clear_flag(state)
             return
         if self.key in value['conversations']:
             value['conversations'].remove(self.key)

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -464,16 +464,15 @@ class TestConversation(unittest.TestCase):
         conv.remove_state('{relation_name}.bar')
         get_flag_value.assert_called_once_with('rel.bar')
         assert not set_flag.called
-        assert not clear_flag.called
+        assert clear_flag.called
 
         conv.remove_state('{relation_name}.bar')
         set_flag.assert_called_once_with('rel.bar', {'conversations': ['foo']})
-        assert not clear_flag.called
+        assert clear_flag.called
 
         set_flag.reset_mock()
         conv.remove_state('{relation_name}.bar')
         assert not set_flag.called
-        clear_flag.assert_called_once_with('rel.bar')
 
     @mock.patch.object(relations, '_get_flag_value')
     def test_is_state(self, get_flag_value):


### PR DESCRIPTION
This patchset implements a logic to remove the state when its value
is set to "None".

Partial-Bug: 1721580