### PR TITLE
Rename Endpoint.joined to Endpoint.is_joined

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -164,7 +164,7 @@ class Endpoint(RelationFactory):
         return self._relations
 
     @property
-    def joined(self):
+    def is_joined(self):
         """
         Whether this endpoint has remote applications attached to it.
         """
@@ -203,7 +203,7 @@ class Endpoint(RelationFactory):
         rel_hook = hook_name.startswith(self.endpoint_name + '-relation-')
         departed_hook = rel_hook and hook_name.endswith('-departed')
 
-        toggle_flag(self.expand_name('joined'), self.joined)
+        toggle_flag(self.expand_name('joined'), self.is_joined)
 
         if departed_hook:
             set_flag(self.expand_name('departed'))

--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -170,6 +170,14 @@ class Endpoint(RelationFactory):
         """
         return len(self.all_units) > 0
 
+    @property
+    def joined(self):
+        """
+        .. deprecated:: 0.6.3
+           Use :attr:`is_joined` instead
+        """
+        return self.is_joined
+
     def expand_name(self, flag):
         """
         Complete a flag for this endpoint by expanding the endpoint name.

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -164,12 +164,14 @@ class TestEndpoint(unittest.TestCase):
         assert Endpoint.from_name('test-endpoint') is not None
         assert Endpoint.from_name('test-endpoint').endpoint_name == 'test-endpoint'
         assert Endpoint.from_name('test-endpoint').is_joined
+        assert Endpoint.from_name('test-endpoint').joined  # deprecated
         assert is_flag_set('endpoint.test-endpoint.joined')
         assert is_flag_set('endpoint.test-endpoint.changed')
         assert is_flag_set('endpoint.test-endpoint.changed.foo')
         assert Endpoint.from_name('test-endpoint2') is not None
         assert Endpoint.from_name('test-endpoint2').endpoint_name == 'test-endpoint2'
         assert not Endpoint.from_name('test-endpoint2').is_joined
+        assert not Endpoint.from_name('test-endpoint2').joined  # deprecated
         assert not is_flag_set('endpoint.test-endpoint2.joined')
         assert not is_flag_set('endpoint.test-endpoint2.changed')
         assert not is_flag_set('endpoint.test-endpoint2.changed.foo')

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -163,13 +163,13 @@ class TestEndpoint(unittest.TestCase):
         Endpoint._startup()
         assert Endpoint.from_name('test-endpoint') is not None
         assert Endpoint.from_name('test-endpoint').endpoint_name == 'test-endpoint'
-        assert Endpoint.from_name('test-endpoint').joined
+        assert Endpoint.from_name('test-endpoint').is_joined
         assert is_flag_set('endpoint.test-endpoint.joined')
         assert is_flag_set('endpoint.test-endpoint.changed')
         assert is_flag_set('endpoint.test-endpoint.changed.foo')
         assert Endpoint.from_name('test-endpoint2') is not None
         assert Endpoint.from_name('test-endpoint2').endpoint_name == 'test-endpoint2'
-        assert not Endpoint.from_name('test-endpoint2').joined
+        assert not Endpoint.from_name('test-endpoint2').is_joined
         assert not is_flag_set('endpoint.test-endpoint2.joined')
         assert not is_flag_set('endpoint.test-endpoint2.changed')
         assert not is_flag_set('endpoint.test-endpoint2.changed.foo')


### PR DESCRIPTION
It came up that an interface layer could easily want to name a handler `joined` which ends up conflicting with the property and breaking the management of the `endpoint.{endpoint_name}.joined` flag causing it to always be set, even when no related units are joined.

The `is_joined` name is more descriptive to indicate that it's a boolean flag, anyway.