### PR TITLE
Make Endpoint.from_flag return None for unset flags

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -97,10 +97,10 @@ class Endpoint(RelationFactory):
         The ``{name}}`` portion will be passed to
         :meth:`~charms.reactive.endpoints.Endpoint.from_name`.
 
-        If an appropriate Endpoint sublcass cannot be found, or the flag name
-        can't be parsed, ``None`` will be returned.
+        If the flag is not set, an appropriate Endpoint subclass cannot be
+        found, or the flag name can't be parsed, ``None`` will be returned.
         """
-        if '.' not in flag:
+        if not is_flag_set(flag) or '.' not in flag:
             return None
         parts = flag.split('.')
         if parts[0] == 'endpoint':

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -21,7 +21,7 @@ import unittest
 from pathlib import Path
 
 from charmhelpers.core import unitdata
-from charms.reactive import Endpoint, is_flag_set, clear_flag
+from charms.reactive import Endpoint, set_flag, is_flag_set, clear_flag
 from charms.reactive.bus import discover, dispatch, Handler
 
 
@@ -150,8 +150,14 @@ class TestEndpoint(unittest.TestCase):
         self.assertIsNone(Endpoint.from_flag('foo'))
         self.assertIsNone(Endpoint.from_flag('bar.qux.zod'))
 
+        # should return None for unset flag
+        self.assertIsNone(Endpoint.from_flag('endpoint.foo.qux'))
+
+        # once flag is set, should return the endpoint
+        set_flag('endpoint.foo.qux')
         self.assertIs(Endpoint.from_flag('endpoint.foo.qux'), endpoint)
 
+        set_flag('foo.qux')
         self.assertIs(Endpoint.from_flag('foo.qux'), endpoint)
 
     def test_startup(self):


### PR DESCRIPTION
The behavior of `endpoint_from_flag` should be consistent whether the interface layer uses RelationBase or Endpoint. For `RelationBase` and unset flags, it returns `None`, so it should for `Endpoint` as well.

You can always use `endpoint_from_name` to get an instance of the unjoined endpoint.