### PR TITLE
Catch Exception rather than json.JSONDecodeError for Python 3.4

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -829,7 +829,8 @@ class JSONUnitDataView(UserDict):
             return value
         try:
             return json.loads(value)
-        except json.JSONDecodeError:
+        except Exception:
+            # Catch json.JSONDecodeError when we drop Python 3.4 support.
             return value
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
Catching Exception should be good enough, as the only call being made
is json.loads() and it won't catch system exceptions such as memory
issues. Still, we should tighten it back up once we can drop
Python 3.4 support with the Ubuntu 14.04 EOL.

Addresses #180