### PR TITLE
Manage automatic flags in the library

### DIFF
--- a/charms/reactive/__init__.py
+++ b/charms/reactive/__init__.py
@@ -15,7 +15,6 @@
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import traceback
 
 from .flags import *  # noqa
@@ -55,7 +54,8 @@ def main(relation_name=None):
 
     :param str relation_name: Optional name of the relation which is being handled.
     """
-    restricted_mode = hookenv.hook_name() in ['meter-status-changed', 'collect-metrics']
+    hook_name = hookenv.hook_name()
+    restricted_mode = hook_name in ['meter-status-changed', 'collect-metrics']
 
     hookenv.log('Reactive main running for hook %s' % hookenv.hook_name(), level=hookenv.INFO)
     if restricted_mode:
@@ -64,7 +64,7 @@ def main(relation_name=None):
     # work-around for https://bugs.launchpad.net/juju-core/+bug/1503039
     # ensure that external handlers can tell what hook they're running in
     if 'JUJU_HOOK_NAME' not in os.environ:
-        os.environ['JUJU_HOOK_NAME'] = os.path.basename(sys.argv[0])
+        os.environ['JUJU_HOOK_NAME'] = hook_name
 
     try:
         bus.discover()

--- a/charms/reactive/helpers.py
+++ b/charms/reactive/helpers.py
@@ -17,19 +17,26 @@
 import re
 import json
 import hashlib
+from pathlib import Path
 
 from charmhelpers.core import host
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
 from charmhelpers.cli import cmdline
 from charms.reactive.flags import any_flags_set, all_flags_set
+from charms.reactive.flags import set_flag, toggle_flag
 # import deprecated functions for backwards compatibility
 from charms.reactive.flags import is_state, all_states, any_states  # noqa
 
 
 __all__ = [
     'data_changed',
+    'file_changed',
     'any_file_changed',
+    'resource_changed',
+    'any_resource_changed',
+    'leader_set',
+    'leader_get',
 ]
 
 
@@ -81,6 +88,24 @@ def any_hook(*hook_patterns):
     return current_hook in hook_patterns
 
 
+def file_changed(filename, hash_type):
+    """
+    Check if the given file has changed since the last time this was called.
+
+    :param str filename: Name of file to check. Accepts a callable returning
+        the filename.
+    :param str hash_type: Algorithm to use to check the files.
+    """
+    if callable(filename):
+        filename = str(filename())
+    else:
+        filename = str(filename)
+    old_hash = unitdata.kv().get('reactive.files_changed.%s' % filename)
+    new_hash = host.file_hash(filename, hash_type=hash_type)
+    unitdata.kv().set('reactive.files_changed.%s' % filename, new_hash)
+    return old_hash != new_hash
+
+
 def any_file_changed(filenames, hash_type='md5'):
     """
     Check if any of the given files have changed since the last time this
@@ -90,18 +115,7 @@ def any_file_changed(filenames, hash_type='md5'):
         the filename.
     :param str hash_type: Algorithm to use to check the files.
     """
-    changed = False
-    for filename in filenames:
-        if callable(filename):
-            filename = str(filename())
-        else:
-            filename = str(filename)
-        old_hash = unitdata.kv().get('reactive.files_changed.%s' % filename)
-        new_hash = host.file_hash(filename, hash_type=hash_type)
-        if old_hash != new_hash:
-            unitdata.kv().set('reactive.files_changed.%s' % filename, new_hash)
-            changed = True  # mark as changed, but keep updating hashes
-    return changed
+    return any([file_changed(filename, hash_type) for filename in filenames])
 
 
 def was_invoked(invocation_id):
@@ -148,6 +162,107 @@ def data_changed(data_id, data, hash_type='md5'):
     new_hash = alg(serialized).hexdigest()
     unitdata.kv().set(key, new_hash)
     return old_hash != new_hash
+
+
+def resource_changed(resource_name, hash_type='md5'):
+    """
+    Check if the given resource has changed since the previous call.
+
+    This works by using :func:`~charms.reactive.helpers.file_changed` on the
+    result of resource_get_.  Note that calling this will fetch the resource
+    from the controller if it hasn't been already, incuring network and disk
+    usage.
+
+    If the resource is an empty (zero-byte) file, if the resource can't be
+    fetched, or if resources are not supported on the current controller
+    version, it will return ``None`` instead of ``True`` or ``False``.
+
+    :param str resource_name: Name of a resource defined in ``metadata.yaml``.
+    :param str hash_type: Any hash algorithm supported by :mod:`hashlib`.
+
+    :returns: ``True``, ``False``, or ``None``.
+
+    .. _resource_get: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.hookenv.html#charmhelpers.core.hookenv.resource_get
+    """
+    try:
+        resource_file = hookenv.resource_get(resource_name)
+        if resource_file is False:
+            return None
+        if Path(resource_file).stat().st_size == 0:
+            return None
+        return file_changed(resource_file, hash_type)
+    except NotImplementedError:
+        return None
+
+
+def any_resource_changed(resource_names, hash_type='md5'):
+    """
+    Check if any of the named resources have changed, using
+    :func:`~charms.reactive.helpers.resource_changed`.
+
+    :param list resource_names: List of resource names to check.
+    :param str hash_type: Any hash algorithm supported by :mod:`hashlib`.
+
+    :returns: ``True`` if any resource has changed, ``False`` if no resource
+        has changed, or ``None`` if any resource cannot be fetched or were
+        empty and none that could be fetched have changed.
+    """
+    results = [resource_changed(resource_name, hash_type)
+               for resource_name in resource_names]
+    if any(results):
+        return True
+    elif None in results:
+        return None
+    else:
+        return False
+
+
+def leader_set(*args, **kw):
+    """
+    Change leadership settings, ensuring that the leadership flags are updated.
+
+    Settings may either be passed in as a single dictionary, or using keyword
+    arguments. All values must be strings.
+
+    The ``leadership.set.{setting_name}`` flag will be set if the value is not
+    ``None``.
+
+    Changed leadership settings will set the ``leadership.changed.{setting_name}``
+    and ``leadership.changed`` flags.
+
+    These flag changes take effect immediately on the leader, and
+    in future hooks run on non-leaders. In this way both leaders and
+    non-leaders can share handlers, waiting on these flags.  Note that if you
+    use charmhelpers's leader_set_ directly, other handlers on the
+    leader may never be notified of the change.
+
+    See :ref:`automatic-flags` for more information on the managed flags.
+
+    .. _leader_set: https://charm-helpers.readthedocs.io/en/latest/api/charmhelpers.core.hookenv.html#charmhelpers.core.hookenv.leader_set
+    """
+    if args:
+        if len(args) > 1:
+            raise TypeError('leader_set() takes 1 positional argument but '
+                            '{} were given'.format(len(args)))
+        else:
+            settings = dict(args[0])
+    else:
+        settings = {}
+    settings.update(kw)
+    previous = unitdata.kv().getrange('leadership.settings.', strip=True)
+
+    for key, value in settings.items():
+        if value != previous.get(key):
+            set_flag('leadership.changed.{}'.format(key))
+            set_flag('leadership.changed')
+        toggle_flag('leadership.set.{}'.format(key), value is not None)
+    hookenv.leader_set(settings)
+    unitdata.kv().update(settings, prefix='leadership.settings.')
+
+
+def leader_get(attribute=None):
+    '''Return leadership settings, per charmhelpers.core.hookenv.leader_get.'''
+    return hookenv.leader_get(attribute)
 
 
 def _hook(hook_patterns):

--- a/docs/_extensions/automembersummary.py
+++ b/docs/_extensions/automembersummary.py
@@ -44,9 +44,12 @@ class AutoMemberSummary(Autosummary):
 
         def _get_items(name):
             _items = super(AutoMemberSummary, self).get_items([shorten + name])
+            if self.result.data and ".. deprecated::" in self.result.data[0]:
+                # don't show deprecated classes / functions in summary
+                return
             for dn, sig, summary, rn in _items:
-                # Don't show deprecated methods in summary
                 if ".. deprecated::" in summary:
+                    # don't show deprecated methods in summary
                     continue
                 items.append(('%s%s' % (prefix, dn), sig, summary, rn))
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,3 +5,8 @@
 .rst-content code.xref {
     color: #2980B9;
 }
+
+#automatic-flags td,
+#reactive-api-documentation td {
+    white-space: normal;
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Table of Contents
    :maxdepth: 3
 
    structure
+   managed-flags
    layer-basic
    bash-reactive
    faq

--- a/docs/layer-basic.md
+++ b/docs/layer-basic.md
@@ -48,8 +48,7 @@ directory.
 .. note:: Because ``update-status`` is invoked every 5 minutes, you should take
    care to ensure that your reactive handlers only invoke expensive operations
    when absolutely necessary.  It is recommended that you use helpers like
-   :func:`@when_file_changed <charms.reactive.decorators.when_file_changed>`,
-   and :func:`@data_changed <charms.reactive.helpers.data_changed>` to ensure
+   :func:`@data_changed <charms.reactive.helpers.data_changed>` to ensure
    that handlers run only when necessary.
 ```
 
@@ -87,6 +86,16 @@ def my_opt_changed():
     restart_service()
 ```
 
+```eval_rst
+.. note:: The config flag are now managed by the reactive library directly,
+  however, the behavior with respect to automatic removal is changing slightly.
+  The existing behavior is selected by setting the ``autoremove_config_flags``
+  layer option to ``true``, which is currently the default but is expected to
+  change.  See :ref:`automatic-flags` and
+  :ref:`Layer Configuration <layer-basic/layer-config>` for
+  more info.
+```
+
 
 ```eval_rst
 .. _layer-basic/layer-config:
@@ -116,6 +125,18 @@ This layer supports the following options, which can be set in `layer.yaml`:
     the `--system-site-packages` options to make system Python libraries
     visible within the venv.
 
+  * **autoremove_config_flags** If set to true, the legacy behavior of
+    automatically removing the various `config.*` flags is enabled.  Otherwise,
+    the flags will not be removed and they should be removed by the top-level
+    charm layer as processed, while base layers should use [triggers].
+    
+    ```eval_rst
+    .. note:: The current default value for ``autoremove_config_flags`` is
+       ``true`` but is expected to change to ``false`` in the future.
+    ```
+
+[triggers]: https://charmsreactive.readthedocs.io/en/latest/charms.reactive.flags.html#charms.reactive.flags.register_trigger
+
 An example `layer.yaml` using these options might be:
 
 ```yaml
@@ -125,6 +146,7 @@ options:
     packages: ['git']
     use_venv: true
     include_system_packages: true
+    autoremove_config_flags: false
 ```
 
 

--- a/docs/managed-flags.rst
+++ b/docs/managed-flags.rst
@@ -1,0 +1,96 @@
+.. _automatic-flags:
+
+Automatic Flags
+===============
+
+The reactive framework will automatically set some flags for your charm,
+based on lifecycle events from Juju.  These flags can inform your charm
+of things such as upgrades, config changes, relation activity, etc.
+
+With a few exceptions, these flags will be set by the framework but it is up
+to your charm to clear them, if need be.  To avoid conflicts between layers,
+it is recommended that only the top-level charm layer (or interface layer, in
+the case of endpoint flags) use any of the automatic flags directly; any base 
+layer should instead use :func:`~charms.reactive.flags.register_trigger` to
+"wrap" the automatic flag with a layer-specific flag that can be safely used
+within that layer.
+
+The flags that are set by the framework are:
+
++----------------------------------------------+------------------------------------------------------------+
+| ``upgrade.charm.completed``                  | This is set when a new revision of the charm               |
+|                                              | code has landed on the unit.                               |
++----------------------------------------------+------------------------------------------------------------+
+| ``upgrade.resources.check``                  | This is set when new versions of charm resources may be    |
+|                                              | available, as indicated by the ``upgrade-charm`` hook      |
+|                                              | having been called.  However, to avoid fetching and        |
+|                                              | storing resources unnecessarily, no resources are          |
+|                                              | actually checked, so you will need to use                  |
+|                                              | :func:`~charms.reactive.helpers.resource_changed` or       |
+|                                              | :func:`~charms.reactive.helpers.any_resource_changed`      |
+|                                              | to determine which, if any, resources were actually        |
+|                                              | updated.                                                   |
++----------------------------------------------+------------------------------------------------------------+
+| ``upgrade.series.started``                   | This is set when the ``pre-series-upgrade`` hook is        |
+|                                              | fired, indicating that any application services should     |
+|                                              | be stopped and disabled so that they do not start on       |
+|                                              | reboot, so that the operator can perform a OS series       |
+|                                              | upgrade.                                                   |
++----------------------------------------------+------------------------------------------------------------+
+| ``upgrade.series.completed``                 | This is set when the ``post-series-upgrade`` hook is       |
+|                                              | fired, indicating that the operator has completed the      |
+|                                              | series upgrade and any application migrations should be    |
+|                                              | performed and any services should be resumed and           |
+|                                              | re-enabled.                                                |
++----------------------------------------------+------------------------------------------------------------+
+| ``config.changed``                           | This is set when any config option has changed.            |
++----------------------------------------------+------------------------------------------------------------+
+| ``config.changed.{option_name}``             | This is set for each config option that has changed.       |
++----------------------------------------------+------------------------------------------------------------+
+| ``config.set.{option_name}``                 | This is set for each config option whose value is not      |
+|                                              | ``None``, ``False``, or an empty string.                   |
++----------------------------------------------+------------------------------------------------------------+
+| ``config.default.{option_name}``             | This is set for each config option whose value was         |
+|                                              | changed from its default.                                  |
++----------------------------------------------+------------------------------------------------------------+
+| ``leadership.is_leader``                     | This is set when the unit is the leader. The unit will     |
+|                                              | remain the leader for the remainder of the hook, but       |
+|                                              | may not be leader in future hooks.                         |
++----------------------------------------------+------------------------------------------------------------+
+| ``leadership.changed``                       | This is set when any leadership setting has changed.       |
++----------------------------------------------+------------------------------------------------------------+
+| ``leadership.changed.{setting_name}``        | This is set for each leadership setting that has           |
+|                                              | changed.                                                   |
++----------------------------------------------+------------------------------------------------------------+
+| ``leadership.set.{setting_name}``            | This is set for each leadership setting that has been      |
+|                                              | to set to a value other than ``None``.                     |
++----------------------------------------------+------------------------------------------------------------+
+| ``endpoint.{endpoint_name}.joined``          | This is set when a relation is joined on an endpoint. [1]_ |
++----------------------------------------------+------------------------------------------------------------+
+| ``endpoint.{endpoint_name}.changed``         | This is set when relation data has changed. [1]_           |
++----------------------------------------------+------------------------------------------------------------+
+| ``endpoint.{endpoint_name}.changed.{field}`` | This is set for each field of relation data which has      |
+|                                              | changed. [1]_                                              |
++----------------------------------------------+------------------------------------------------------------+
+| ``endpoint.{endpoint_name}.departed``        | This is set when a unit leaves a relation. [1]_            |
++----------------------------------------------+------------------------------------------------------------+
+
+.. [1]
+
+  See :class:`~charms.reactive.endpoints.Endpoint` for more information
+  on the ``endpoint.{endpoint_name}.*`` flags.
+
+.. note::
+
+  The behaivor of the leadership and config flags when managed by this library
+  differs slightly from when they are managed by the leadership and basic
+  layer, respectively.  Specifically, those layers perform automatic removal
+  of the flags at the end of the hook context in which they are set, while
+  this library does not.
+
+  If the leadership layer is included, or if the basic layer's
+  ``autoremove_config_flags`` option is set to ``true`` (currently the
+  default), then those layers will take precedence over this layer and the
+  flags will be automatically removed.  It is recommended, however, that
+  charms move toward using triggers and removing the flags manually in the
+  charm layer.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -158,6 +158,11 @@ class TestReactiveHelpers(unittest.TestCase):
     @mock.patch('charmhelpers.core.host.file_hash')
     def test_any_file_changed_argtypes(self, file_hash):
         file_hash.return_value = 'beep'
+        self.kv.update({
+            'one': 'beep',
+            'two': 'beep',
+            '3': 'beep',
+        }, prefix='reactive.files_changed.')
         # A filename may be a callable, in which case it is called and
         # the result used, and are cast to strings.
         reactive.helpers.any_file_changed(['one', lambda: 'two', 3])


### PR DESCRIPTION
This pulls in the automatic flags that are currently managed by the leadership and basic layer, as well as adding support for flags tracking the upgrade of charm, resource, and OS series.  It also adds a docs page documenting all of the automatically managed flags in one place, as well as the recommended conventions for interacting with them.

Resolves #177 (see the discussion there for more info; I don't know that this PR fully addresses everything from there, so it may require some iteration)