### PR TITLE
Flag and handler trace

### DIFF
--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -379,10 +379,12 @@ def dispatch(restricted=False):
     _invoke(hook_handlers)
 
     unitdata.kv().set('reactive.dispatch.phase', 'other')
-    tracer().start_dispatch_loop()
     for i in range(100):
         FlagWatch.iteration(i)
         other_handlers = _test(Handler.get_handlers())
+        if i == 0:
+            tracer().start_dispatch_phase('other', other_handlers)
+        tracer().start_dispatch_iteration(i, other_handlers)
         if not other_handlers:
             break
         _invoke(other_handlers)

--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -93,7 +93,7 @@ class Handler(object):
     @classmethod
     def get_handlers(cls):
         """
-        Clear all registered handlers.
+        Get all registered handlers.
         """
         return cls._HANDLERS.values()
 

--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -24,6 +24,7 @@ from functools import partial
 
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
+from charms.reactive.trace import tracer
 
 
 _log_opts = os.environ.get('REACTIVE_LOG_OPTS', '').split(',')
@@ -362,18 +363,23 @@ def dispatch(restricted=False):
                     break
         FlagWatch.commit()
 
+    tracer().start_dispatch()
+
     # When in restricted context, only run hooks for that context.
     if restricted:
         unitdata.kv().set('reactive.dispatch.phase', 'restricted')
         hook_handlers = _test(Handler.get_handlers())
+        tracer().start_dispatch_phase('restricted', hook_handlers)
         _invoke(hook_handlers)
         return
 
     unitdata.kv().set('reactive.dispatch.phase', 'hooks')
     hook_handlers = _test(Handler.get_handlers())
+    tracer().start_dispatch_phase('hooks', hook_handlers)
     _invoke(hook_handlers)
 
     unitdata.kv().set('reactive.dispatch.phase', 'other')
+    tracer().start_dispatch_loop()
     for i in range(100):
         FlagWatch.iteration(i)
         other_handlers = _test(Handler.get_handlers())

--- a/charms/reactive/flags.py
+++ b/charms/reactive/flags.py
@@ -1,9 +1,10 @@
-
 from charmhelpers.cli import cmdline
 from charmhelpers.core import hookenv
 from charmhelpers.core import unitdata
 
 from charms.reactive.bus import FlagWatch
+from charms.reactive.trace import tracer
+
 
 __all__ = [
     'set_flag',
@@ -74,6 +75,7 @@ def set_flag(flag, value=None):
     old_flags = get_flags()
     unitdata.kv().update({flag: value}, prefix='reactive.states.')
     if flag not in old_flags:
+        tracer().set_flag(flag)
         FlagWatch.change(flag)
         trigger = _get_trigger(flag)
         for flag_name in trigger['set_flag']:
@@ -99,6 +101,7 @@ def clear_flag(flag):
     unitdata.kv().unset('reactive.states.%s' % flag)
     unitdata.kv().set('reactive.dispatch.removed_state', True)
     if flag in old_flags:
+        tracer().clear_flag(flag)
         FlagWatch.change(flag)
 
 

--- a/charms/reactive/trace.py
+++ b/charms/reactive/trace.py
@@ -1,3 +1,5 @@
+from charmhelpers.core import hookenv
+
 from charms.reactive import bus
 
 
@@ -10,6 +12,11 @@ class NullTracer(object):
 
 
 class LogTracer(NullTracer):
+    LEVEL = hookenv.DEBUG
+
+    def __init__(self):
+        self._msgs = []
+
     def set_flag(self, flag):
         self._flag("flag {} set".format(flag))
 
@@ -17,22 +24,31 @@ class LogTracer(NullTracer):
         self._flag("flag {} cleared".format(flag))
 
     def _emit(self, msg):
-        print("tracer: {}".format(msg))
+        self._msgs.append("tracer: {}".format(msg))
 
-    _enabled_handlers = frozenset()
+    def _flush(self):
+        if self._msgs:
+            if len(self._msgs) > 1:
+                self._msgs.insert(0, "tracer>")
+            hookenv.log("\n".join(self._msgs), self.LEVEL)
+            self._msgs = []
+
+    _active_handlers = frozenset()
 
     def _flag(self, msg):
         self._emit(msg)
-        prev_handlers = self._enabled_handlers
+        prev_handlers = self._active_handlers
         next_handlers = set(h for h in bus.Handler.get_handlers() if h.test())
 
         for h in sorted(h.id() for h in (next_handlers - prev_handlers)):
-            self._emit("++ queue   handler {}".format(h))
+            self._emit("++   queue handler {}".format(h))
 
         for h in sorted(h.id() for h in (prev_handlers - next_handlers)):
             self._emit("-- dequeue handler {}".format(h))
 
-        self._enabled_handlers = next_handlers
+        self._flush()
+
+        self._active_handlers = next_handlers
 
 
 _tracer = None
@@ -41,6 +57,9 @@ _tracer = None
 def install_tracer(tracer):
     global _tracer
     _tracer = tracer
+    # Disable tracing when we hit atexit, to avoid spam from layers
+    # like the base layer tearing down flags.
+    hookenv.atexit(install_tracer, NullTracer())
 
 
 def tracer():

--- a/charms/reactive/trace.py
+++ b/charms/reactive/trace.py
@@ -1,9 +1,21 @@
 from charmhelpers.core import hookenv
 
-from charms.reactive import bus
+from charms.reactive import bus, flags
 
 
 class NullTracer(object):
+    """
+    NullTracer is the default tracer and tracer base class, and does nothing
+    """
+    def start_dispatch(self):
+        pass
+
+    def start_dispatch_phase(self, phase, handlers):
+        pass
+
+    def start_dispatch_loop(self):
+        pass
+
     def set_flag(self, flag):
         pass
 
@@ -12,16 +24,43 @@ class NullTracer(object):
 
 
 class LogTracer(NullTracer):
+    """
+    LogTracer logs flags and handler activation to the Juju charm log
+
+    Expect formatting and verbosity to change in future releases.
+    """
     LEVEL = hookenv.DEBUG
 
     def __init__(self):
+        self._active_handlers = set()
         self._msgs = []
 
+    def start_dispatch(self):
+        all_flags = flags.get_flags()
+        self._emit("starting handler dispatch, {} flags set".format(len(all_flags)))
+        for f in all_flags:
+            self._emit("set flag {}".format(f))
+        self._flush()
+
+    def start_dispatch_phase(self, phase, handlers):
+        self._emit("{} phase, {} handlers".format(phase, len(handlers)))
+        self._active_handlers = set(handlers)
+        for h in sorted(h.id() for h in handlers):
+            self._emit("++   queue handler {}".format(h))
+        self._flush()
+
+    def start_dispatch_loop(self):
+        self._active_handlers = set(h for h in bus.Handler.get_handlers() if h.test())
+        self._emit("main dispatch loop, {} handlers initially queued".format(len(self._active_handlers)))
+        for h in sorted(h.id() for h in self._active_handlers):
+            self._emit("++   queue handler {}".format(h))
+        self._flush()
+
     def set_flag(self, flag):
-        self._flag("flag {} set".format(flag))
+        self._flag("set flag {}".format(flag))
 
     def clear_flag(self, flag):
-        self._flag("flag {} cleared".format(flag))
+        self._flag("cleared flag {}".format(flag))
 
     def _emit(self, msg):
         self._msgs.append("tracer: {}".format(msg))
@@ -32,8 +71,6 @@ class LogTracer(NullTracer):
                 self._msgs.insert(0, "tracer>")
             hookenv.log("\n".join(self._msgs), self.LEVEL)
             self._msgs = []
-
-    _active_handlers = frozenset()
 
     def _flag(self, msg):
         self._emit(msg)
@@ -58,7 +95,7 @@ def install_tracer(tracer):
     global _tracer
     _tracer = tracer
     # Disable tracing when we hit atexit, to avoid spam from layers
-    # like the base layer tearing down flags.
+    # such as the base layer tearing down flags.
     hookenv.atexit(install_tracer, NullTracer())
 
 

--- a/charms/reactive/trace.py
+++ b/charms/reactive/trace.py
@@ -1,0 +1,51 @@
+from charms.reactive import bus
+
+
+class NullTracer(object):
+    def set_flag(self, flag):
+        pass
+
+    def clear_flag(self, flag):
+        pass
+
+
+class LogTracer(NullTracer):
+    def set_flag(self, flag):
+        self._flag("flag {} set".format(flag))
+
+    def clear_flag(self, flag):
+        self._flag("flag {} cleared".format(flag))
+
+    def _emit(self, msg):
+        print("tracer: {}".format(msg))
+
+    _enabled_handlers = frozenset()
+
+    def _flag(self, msg):
+        self._emit(msg)
+        prev_handlers = self._enabled_handlers
+        next_handlers = set(h for h in bus.Handler.get_handlers() if h.test())
+
+        for h in sorted(h.id() for h in (next_handlers - prev_handlers)):
+            self._emit("++ queue   handler {}".format(h))
+
+        for h in sorted(h.id() for h in (prev_handlers - next_handlers)):
+            self._emit("-- dequeue handler {}".format(h))
+
+        self._enabled_handlers = next_handlers
+
+
+_tracer = None
+
+
+def install_tracer(tracer):
+    global _tracer
+    _tracer = tracer
+
+
+def tracer():
+    global _tracer
+    return _tracer
+
+
+install_tracer(NullTracer())

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -582,6 +582,19 @@ class TestReactiveBus(unittest.TestCase):
         sys.path.pop()  # Repair sys.path
         sys.path.pop()
 
+    @attr('slow')
+    @mock.patch('charmhelpers.core.hookenv.log')
+    def test_full_stack_with_tracing(self, log):
+        self.addCleanup(reactive.trace.install_tracer, reactive.trace.NullTracer())
+        tracer = mock.Mock(wraps=reactive.trace.LogTracer())
+        reactive.trace.install_tracer(tracer)
+        self.test_full_stack()
+        log.assert_called()
+        tracer.start_dispatch.assert_called()
+        tracer.start_dispatch_phase.assert_any_call('hooks', mock.ANY)
+        tracer.start_dispatch_phase.assert_any_call('other', mock.ANY)
+        tracer.start_dispatch_iteration.assert_any_call(0, mock.ANY)
+
     @mock.patch.object(reactive.bus.importlib, 'import_module')
     def test_load_module_py3(self, import_module):
         import_module.side_effect = lambda x: x

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,65 @@
+# Copyright 2018 Canonical Limited.
+#
+# This file is part of charms.reactive.
+#
+# charms.reactive is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# charm-helpers is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
+
+from textwrap import dedent
+import unittest
+from unittest import mock
+
+from charms import reactive
+
+
+class TestTracer(unittest.TestCase):
+    def test_nulltracer_api(self):
+        self._test_api(reactive.trace.NullTracer())
+
+    @mock.patch('charms.reactive.bus._short_action_id')
+    @mock.patch('charms.reactive.bus.Handler.get_handlers')
+    @mock.patch('charmhelpers.core.hookenv.log')
+    def test_logtracer_api(self, log, gh, sid):
+        sid.side_effect = lambda x, y: x
+        h = reactive.bus.Handler
+        gh.side_effect = [
+            [h('handler_1')],
+            [h('handler_2'), h('handler_3')],
+        ]
+        self._test_api(reactive.trace.LogTracer())
+        # We are not wedded to this format. We should change it if we
+        # can come up with something more generally readable. Multiline
+        # strings are used to avoid hookenv.log call overhead (juju-log is
+        # expensive), but that might be premature optimization.
+        log.assert_has_calls([
+            mock.call('tracer: starting handler dispatch, 0 flags set', 'DEBUG'),
+            mock.call('tracer: hooks phase, 0 handlers queued', 'DEBUG'),
+            mock.call(dedent('''\
+                      tracer>
+                      tracer: set flag flag_a
+                      tracer: ++   queue handler handler_1
+                      ''').strip(), 'DEBUG'),
+            mock.call(dedent('''\
+                      tracer>
+                      tracer: cleared flag flag_b
+                      tracer: ++   queue handler handler_2
+                      tracer: ++   queue handler handler_3
+                      tracer: -- dequeue handler handler_1
+                      ''').strip(), 'DEBUG'),
+        ])
+
+    def _test_api(self, imp):
+        imp.start_dispatch()
+        imp.start_dispatch_phase('hooks', [])
+        imp.start_dispatch_iteration(0, [])
+        imp.set_flag('flag_a')
+        imp.clear_flag('flag_b')


### PR DESCRIPTION
Working out which handlers will fire and when seems difficult for many developers starting out with charms.reactive. I think an option to log flag changes and the effects they trigger will help them understand the logic and track down bugs and race conditions.

For an example of what this ends up looking like, see https://pastebin.ubuntu.com/p/GHh8qyG7Yy/

I imagine a few ways that a developer could enable this optional behavior:
 * Creating a file `reactive/trace.py` containing `from charms.reactive import trace; trace.install_tracer(trace.LogTracer())`
 * Including a layer that does the above
 * A layer.yaml option that the base layer uses to turn on the logging.

It may even be worth just leaving it on (rather than consider this a developer option) if the performance hit and log verbosity is not considered a problem. Having this information in logs attached to bug reports could be really useful.
