### PR TITLE
Fix Travis config to work with classic charm snap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build
 .settings
 *~
 charms.reactive.egg-info/
+.unit-state.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install tox-travis
   - sudo snap install lxd --$SNAP_CHANNEL
   - sudo snap install juju --classic --$SNAP_CHANNEL
-  - sudo snap install charm --$SNAP_CHANNEL
+  - sudo snap install charm --classic --$SNAP_CHANNEL
   - sudo snap install --classic juju-wait --$SNAP_CHANNEL
 before_script:
   - sudo addgroup lxd || true

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ clean: docclean
 	rm -rf build/ MANIFEST
 	rm -rf .tox .coverage
 	rm -rf dist/*
+	rm .unit-state.db
 	find . -name '*.pyc' -or -name '__pycache__' | xargs rm -rf
 	(which dh_clean && dh_clean) || true
 


### PR DESCRIPTION
The edge channel of the charm snap has moved to classic confinement, which breaks Travis edge testing.  The `--classic` flag will be ignored when not needed.

Also adds `.unit-state.db` to `.gitignore` and clean.