### PR TITLE
Turn on flag and handler log tracing for all charms

### DIFF
--- a/charms/reactive/trace.py
+++ b/charms/reactive/trace.py
@@ -123,4 +123,12 @@ def tracer():
     return _tracer
 
 
+# On import, the NullTracer is installed to avoid unit tests having
+# to mock hookenv.log.
 install_tracer(NullTracer())
+
+# Install the LogTracer by default, after discovery, before running
+# handlers. If this is too noisy for some, we can make it optional
+# via layer.yaml. Using hookenv.atstart, because the tests already
+# mock it.
+hookenv.atstart(install_tracer, LogTracer())


### PR DESCRIPTION
Charms will now DEBUG log flag changes and the active handlers.
These logs will benefit both charm development and diagnosing
deployment failures, so it is being enabled for all charms.

Per https://github.com/juju-solutions/layer-basic/pull/127#issuecomment-428640498 , the feature is always on. We can add an option to disable it if necessary, or provide a mechanism for charms to override the tracer implementation. This is being implemented in charms.reactive, rather than the base layer, so that all base layers benefit. It could also be a microlayer if someone wants to put it in a suitable github namespace.