### PR TITLE
Add OS Series Upgrades to main docs index page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ ftest: lint
 	.tox/py3/bin/nosetests --attr '!slow' --nologcapture tests/
 
 docs: lint
-	.tox/py3/bin/pip install -r docs/requirements.txt
-	(cd docs; make html SPHINXBUILD=../.tox/py3/bin/sphinx-build)
+	.tox/lint/bin/pip install -r docs/requirements.txt
+	(cd docs; make html SPHINXBUILD=../.tox/lint/bin/sphinx-build)
 	cd docs/_build/html && zip -r ../docs.zip *
 .PHONY: docs
 

--- a/charms/reactive/relations.py
+++ b/charms/reactive/relations.py
@@ -760,7 +760,7 @@ class Conversation(object):
         :param str key: The name of a field to set.
         :param value: A value to set. This value must be json serializable.
         :param dict data: A mapping of keys to values.
-        :param \*\*kwdata: A mapping of keys to values, as keyword arguments.
+        :param **kwdata: A mapping of keys to values, as keyword arguments.
         """
         if data is None:
             data = {}
@@ -820,7 +820,7 @@ class Conversation(object):
         :param str key: The name of a field to set.
         :param value: A value to set. This value must be json serializable.
         :param dict data: A mapping of keys to values.
-        :param \*\*kwdata: A mapping of keys to values, as keyword arguments.
+        :param **kwdata: A mapping of keys to values, as keyword arguments.
         """
         if data is None:
             data = {}

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -6,4 +6,5 @@ Internals and Advanced
 
     dispatch
     triggers
+    series-upgrade
     charms.reactive.bus

--- a/docs/triggers.rst
+++ b/docs/triggers.rst
@@ -1,3 +1,6 @@
+Reactive Triggers
+=================
+
 
 Coupling Flags with Triggers
 ----------------------------

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,3 @@ mock
 nose
 flake8
 ipython
-#ipdb

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ commands = nosetests {posargs}
 
 [testenv:lint]
 basepython = python3
-#envdir = {toxinidir}/.tox/py3
 commands = flake8 {toxinidir}/charms {toxinidir}/tests
 
 [testenv:py3]
@@ -21,7 +20,10 @@ ignore=
     # This project has lines longer than 79 characters
     E501,
     # Lambdas are often more readable, if used carefully
-    E731
+    E731,
+    # flake8 3.6.0 complains about newlines both before and after binary operators
+    # this ignores the after warning, but leaves the before enabled
+    W504,
 exclude=
     .git,
     __pycache__


### PR DESCRIPTION
Currently, it's only discoverable from the Automatic Flags page.

Also fix some lint errors from newer version of flake8, and the `make docs` target.