### PR TITLE
Add ability to trigger on flag being cleared

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -127,6 +127,7 @@ class Endpoint(RelationFactory):
                     else rid for rid in rids]
             endpoint = relf(endpoint_name, rids)
             cls._endpoints[endpoint_name] = endpoint
+            endpoint.register_triggers()
             endpoint._manage_departed()
             endpoint._manage_flags()
             for relation in endpoint.relations:
@@ -138,6 +139,16 @@ class Endpoint(RelationFactory):
                                   key_attr='relation_id')
         self._all_joined_units = None
         self._all_departed_units = None
+
+    def register_triggers(self):
+        """
+        Called once and only once for each named instance of this endpoint,
+        before the endpoint's automatic flags are updated.
+
+        This gives the endpoint implementation a chance to register triggers
+        that will honor changes to the automatically managed flags.
+        """
+        pass
 
     @property
     def endpoint_name(self):

--- a/charms/reactive/flags.py
+++ b/charms/reactive/flags.py
@@ -188,12 +188,6 @@ def _save_trigger(when, when_not, data):
     return unitdata.kv().set(key, data)
 
 
-def _clear_triggers():
-    unitdata.kv().unsetrange(prefix='reactive.flag_triggers.')  # old key
-    unitdata.kv().unsetrange(prefix='reactive.flag_set_triggers.')
-    unitdata.kv().unsetrange(prefix='reactive.flag_clear_triggers.')
-
-
 @cmdline.subcommand()
 @cmdline.test_command
 def is_flag_set(flag):
@@ -308,7 +302,6 @@ def get_state(flag, default=None):
 
 @hookenv.atstart
 def _manage_automatic_flags():
-    _clear_triggers()
     _manage_upgrade_flags()
 
 
@@ -320,3 +313,10 @@ def _manage_upgrade_flags():
 
     if hook_name == 'post-series-upgrade':
         clear_flag('upgrade.series.in-progress')
+
+
+@hookenv.atexit
+def _clear_triggers():
+    unitdata.kv().unsetrange(prefix='reactive.flag_triggers.')  # old key
+    unitdata.kv().unsetrange(prefix='reactive.flag_set_triggers.')
+    unitdata.kv().unsetrange(prefix='reactive.flag_clear_triggers.')

--- a/tests/data/metadata.yaml
+++ b/tests/data/metadata.yaml
@@ -5,3 +5,5 @@ requires:
     interface: 'test-alt'
   test-endpoint2:
     interface: 'test-alt'
+  test-endpoint3:
+    interface: 'test-alt'

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -9,6 +9,7 @@ model="reactive-$nonce"
 CHARM_DIR=$HOME/$model/charms
 BUILD_DIR=$HOME/$model/builds
 
+mkdir "$HOME/$model"
 mkdir "$CHARM_DIR"
 mkdir "$BUILD_DIR"
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -6,21 +6,19 @@ PATH=/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 nonce=$(pwgen -A 8 1)
 model="reactive-$nonce"
-JUJU_REPOSITORY=$HOME/$model
-LAYER_PATH=$JUJU_REPOSITORY/layers
-BUILD_PATH=$JUJU_REPOSITORY/builds
+CHARM_DIR=$HOME/$model/charms
+BUILD_DIR=$HOME/$model/builds
 
-mkdir "$JUJU_REPOSITORY"
-mkdir "$LAYER_PATH"
-mkdir "$BUILD_PATH"
+mkdir "$CHARM_DIR"
+mkdir "$BUILD_DIR"
 
-charm pull-source cs:ghost "$LAYER_PATH"
-charm build "$LAYER_PATH/ghost" -o "$JUJU_REPOSITORY"
+charm pull-source cs:ghost "$CHARM_DIR"
+charm build "$CHARM_DIR/ghost" --build-dir "$BUILD_DIR"
 
 juju add-model "$model"
 juju switch "$model"
 wget 'https://api.jujucharms.com/charmstore/v5/ghost/resource/ghost-stable' -O ghost.zip
-juju deploy "$BUILD_PATH/ghost" --series=xenial
+juju deploy "$BUILD_DIR/ghost" --series=xenial
 juju deploy cs:haproxy
 juju attach ghost ghost-stable=./ghost.zip
 juju add-relation ghost haproxy

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -446,7 +446,7 @@ class TestReactiveBus(unittest.TestCase):
 
         self.assertEqual(len(reactive.bus.Handler.get_handlers()), 0)
         reactive.bus.discover()
-        self.assertEqual(len(reactive.bus.Handler.get_handlers()), 15)
+        self.assertEqual(len(reactive.bus.Handler.get_handlers()), 18)
 
         # The path is extended so discovered modules can perform
         # absolute and relative imports as expected.
@@ -505,7 +505,7 @@ class TestReactiveBus(unittest.TestCase):
         }):
             self.assertEqual(len(reactive.bus.Handler.get_handlers()), 0)
             reactive.bus.discover()
-            self.assertEqual(len(reactive.bus.Handler.get_handlers()), 15)
+            self.assertEqual(len(reactive.bus.Handler.get_handlers()), 18)
 
             reactive.set_flag('test')
             reactive.set_flag('to-remove')

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -21,8 +21,13 @@ import unittest
 from pathlib import Path
 
 from charmhelpers.core import unitdata
-from charms.reactive import Endpoint
-from charms.reactive import set_flag, is_flag_set, clear_flag, register_trigger
+from charms.reactive import (
+    Endpoint,
+    set_flag,
+    is_flag_set,
+    clear_flag,
+    register_trigger,
+)
 from charms.reactive.bus import discover, dispatch, Handler
 
 

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -7,12 +7,10 @@ from charms.reactive import flags
 
 class TestTriggers(unittest.TestCase):
     def setUp(self):
-        self.kv_p = mock.patch('charmhelpers.core.unitdata.kv')
-        kv = self.kv_p.start()
+        kv_p = mock.patch('charmhelpers.core.unitdata.kv')
+        kv = kv_p.start()
+        self.addCleanup(kv_p.stop)
         kv.return_value = MockKV()
-
-    def tearDown(self):
-        self.kv_p.stop()
 
     def test_no_triggers(self):
         assert not flags.any_flags_set('foo', 'bar', 'qux')


### PR DESCRIPTION
Triggers currently allow another flag to be set or cleared when a given flag is set.  This happens as soon as the flag is set, before any handlers are invoked, which is important for ensuring that related flags are handled properly.

This adds the ability to trigger another flag being set or cleared when a given flag is cleared, as well, which addresses race conditions such as the one reported in juju-solutions/interface-public-address#4.

It also includes the ability to define a `register_triggers` method on your `Endpoint` subclass in which you can register triggers that can react to the automatically managed endpoint flags for your specific endpoint.