### PR TITLE
Fix errant str.format handling of flags in expand_name

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -15,7 +15,7 @@
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-from collections import UserDict
+from collections import UserDict, defaultdict
 from itertools import chain
 
 from charmhelpers.core import hookenv, unitdata
@@ -194,12 +194,14 @@ class Endpoint(RelationFactory):
         Complete a flag for this endpoint by expanding the endpoint name.
 
         If the flag does not already contain ``{endpoint_name}``, it will be
-        prefixed with ``endpoint.{endpoint_name}.``. Then, ``str.format`` will
-        be used to fill in ``{endpoint_name}`` with ``self.endpoint_name``.
+        prefixed with ``endpoint.{endpoint_name}.``. Then, any occurance of
+        ``{endpoint_name}`` will be replaced with ``self.endpoint_name``.
         """
         if '{endpoint_name}' not in flag:
             flag = 'endpoint.{endpoint_name}.' + flag
-        return flag.format(endpoint_name=self.endpoint_name)
+        # use replace rather than format to prevent any other braces or braced
+        # strings from being touched
+        return flag.replace('{endpoint_name}', self.endpoint_name)
 
     def _manage_departed(self):
         hook_name = hookenv.hook_name()

--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -15,7 +15,7 @@
 # along with charm-helpers.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-from collections import UserDict, defaultdict
+from collections import UserDict
 from itertools import chain
 
 from charmhelpers.core import hookenv, unitdata


### PR DESCRIPTION
If a flag contains format string constructs, especially `{}`, then `Endpoint.expand_name` will blow up with a very misleading error. Doing this is probably a charm bug, but it is easier to debug if you can see
the flag with the unprocessed format string constructs rather than a random seeming `IndexError`. This changes it to only replace the exact string `{endpoint_name}` to prevent the error.

Example error:

```python-traceback
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-vc-test-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 72, in main
    hookenv._run_atstart()
  File "/var/lib/juju/agents/unit-vc-test-0/.venv/lib/python3.6/site-packages/charmhelpers/core/hookenv.py", line 1206, in _run_atstart
    callback(*args, **kwargs)
  File "/var/lib/juju/agents/unit-vc-test-0/.venv/lib/python3.6/site-packages/charms/reactive/endpoints.py", line 131, in _startup
    endpoint._manage_flags()
  File "/var/lib/juju/agents/unit-vc-test-0/.venv/lib/python3.6/site-packages/charms/reactive/endpoints.py", line 234, in _manage_flags
    set_flag(self.expand_name('changed.{}'.format(key)))
  File "/var/lib/juju/agents/unit-vc-test-0/.venv/lib/python3.6/site-packages/charms/reactive/endpoints.py", line 191, in expand_name
    return flag.format(endpoint_name=self.endpoint_name)
IndexError: tuple index out of range
```