### PR TITLE
Fix config.default.foo automatic flag doc

### DIFF
--- a/docs/managed-flags.rst
+++ b/docs/managed-flags.rst
@@ -29,8 +29,8 @@ The flags that are set by the framework are:
 | ``config.set.{option_name}``                 | This is set for each config option whose value is not      |
 |                                              | ``None``, ``False``, or an empty string. [1]_              |
 +----------------------------------------------+------------------------------------------------------------+
-| ``config.default.{option_name}``             | This is set for each config option whose value was         |
-|                                              | changed from its default. [1]_                             |
+| ``config.default.{option_name}``             | This is set for each config option whose value is equal to |
+|                                              | its default value, and cleared if it has been changed. [1]_|
 +----------------------------------------------+------------------------------------------------------------+
 | ``leadership.is_leader``                     | This is set when the unit is the leader. The unit will     |
 |                                              | remain the leader for the remainder of the hook, but       |


### PR DESCRIPTION
The doc for the `config.default.foo` flag was inverted, claiming that it was set if the value was changed from its default, rather than being set if the value is still set to its default.