### PR TITLE
Drop blacklist in favor of shebang and binary check

### DIFF
--- a/charms/reactive/bus.py
+++ b/charms/reactive/bus.py
@@ -447,12 +447,18 @@ def _load_module(root, filepath):
 def _is_external_handler(filepath):
     if not os.access(filepath, os.X_OK):
         return False
+    _, ext = os.path.splitext(filepath)
+    if ext not in ('', '.sh'):
+        return False
     with open(filepath, 'rb') as fp:
         bytes = fp.read(1024)
-    if bytes.startswith(b'#!'):
+    try:
+        text = bytes.decode('utf8')
+    except UnicodeDecodeError:
+        # binary executable
         return True
-    textchars = bytearray({7, 8, 9, 10, 12, 13, 27} | set(range(0x20, 0x100)) - {0x7f})
-    return bool(bytes.translate(None, textchars))
+    else:
+        return text.startswith('#!')
 
 
 def _register_handlers_from_file(root, filepath):

--- a/tests/data/reactive/__pycache__/not-a-handler
+++ b/tests/data/reactive/__pycache__/not-a-handler
@@ -1,1 +1,1 @@
-#!/bin/false
+# This is not a handler

--- a/tests/data/reactive/not_a_handler.pyc
+++ b/tests/data/reactive/not_a_handler.pyc
@@ -1,1 +1,1 @@
-#!/bin/false
+# Not a handler

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -653,19 +653,20 @@ class TestReactiveBus(unittest.TestCase):
         self.assertIs(sub_mod, sys.modules['reactive.nested.nested'])
 
     @mock.patch.object(reactive.bus.ExternalHandler, 'register')
-    @mock.patch.object(reactive.bus.os, 'access')
+    @mock.patch.object(reactive.bus, '_is_external_handler')
     @mock.patch.object(reactive.bus, '_load_module')
-    def test_register_handlers_from_file(self, _load_module, access, register):
+    def test_register_handlers_from_file(self, _load_module, _is_external_handler, register):
         reactive.bus._register_handlers_from_file('reactive',
                                                   'reactive/foo.py')
         _load_module.assert_called_once_with('reactive',
                                              'reactive/foo.py')
-        access.return_value = True
+        _is_external_handler.return_value = True
         reactive.bus._register_handlers_from_file('reactive', 'reactive/foo')
-        access.assert_called_once_with('reactive/foo', os.X_OK)
+        _is_external_handler.assert_called_once_with('reactive/foo')
         register.assert_called_once_with('reactive/foo')
 
         register.reset_mock()
+        _is_external_handler.return_value = False
         reactive.bus._register_handlers_from_file('hooks/relations',
                                                   'hooks/relations/foo/README.md')
         assert not register.called


### PR DESCRIPTION
Some of the K8s charms are still getting errors after #224 due to files not in the blacklist, so it looks like we need to do the shebang and binary check that @knkski suggested after all.