### PR TITLE
Up-port get_unset_flags from lp:1836063

### DIFF
--- a/charms/reactive/flags.py
+++ b/charms/reactive/flags.py
@@ -232,6 +232,19 @@ def get_flags():
     return sorted(flags.keys())
 
 
+@cmdline.subcommand()
+def get_unset_flags(*desired_flags):
+    """Check if any of the provided flags missing and return them if so.
+
+    :param desired_flags: list of reactive flags
+    :type desired_flags: non-keyword args, str
+    :returns: list of unset flags filtered from the parameters shared
+    :rtype: List[str]
+    """
+    flags = unitdata.kv().getrange('reactive.states.', strip=True) or {}
+    return sorted(set(desired_flags) - flags.keys())
+
+
 def _get_flag_value(flag, default=None):
     return unitdata.kv().get('reactive.states.%s' % flag, default)
 

--- a/charms/reactive/flags.py
+++ b/charms/reactive/flags.py
@@ -15,6 +15,7 @@ __all__ = [
     'all_flags_set',
     'any_flags_set',
     'get_flags',
+    'get_unset_flags',
     'set_state',  # DEPRECATED
     'remove_state',  # DEPRECATED
     'toggle_state',  # DEPRECATED

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -78,6 +78,12 @@ class TestTriggers(unittest.TestCase):
         assert b.call_count == 1
         assert c.call_count == 0
 
+    def test_get_unset_flags(self):
+        self.assertEqual(flags.get_flags(), [])
+        flags.set_flag('foo')
+        self.assertEqual(flags.get_flags(), ['foo'])
+        self.assertEqual(flags.get_unset_flags('foo', 'bar'), ['bar'])
+
 
 class MockKV:
     def __init__(self):


### PR DESCRIPTION
The [PR][] for [lp:1836063][] added a `get_unset_flags` helper to k8s-master which seems generally useful, so this brings it into the lib.

[PR]: https://github.com/charmed-kubernetes/charm-kubernetes-master/pull/135
[lp:1836063]: https://bugs.launchpad.net/charm-kubernetes-master/+bug/1836063