### PR TITLE
Fix AttributeError when accessing received_app

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -855,6 +855,8 @@ class UnitDataView(UserDict):
         return self._writeable
 
     def get(self, key, default=None):
+        if self.data is None:
+            return default
         return self.data.get(key, default)
 
     def __getitem__(self, key):


### PR DESCRIPTION
When received_app property is accessed but the
UnitDataView's data is None, the method tries
to get the value for the key requested, but
throws AttributeError. It is semantically better
to avoid access and return the default value for
the higher layers so this scenario does not have
to be specifically handled there.