### PR TITLE
Fix application_name = None when single cluster relation

### DIFF
--- a/charms/reactive/endpoints.py
+++ b/charms/reactive/endpoints.py
@@ -513,7 +513,7 @@ class Relation:
         if self._remote_app_data is None:
             # using JSONUnitDataView though it's name includes unit.
             self._remote_app_data = JSONUnitDataView(hookenv.relation_get(
-                app=self.application_name,
+                app=hookenv.application_name(),
                 rid=self.relation_id))
         return self._remote_app_data
 


### PR DESCRIPTION
When a cluster relation only has one member, the
self.application_name property used when reading
application databag returns None during a window
of opportunity that is repeated every time a new
hook runs. Subsequent handlers eventually set this property but the first handler that runs causes
issues (in vault charm for example, by failing to get the current certs and then assuming they don't
exist, therefore recreating certs every time
update-status runs).