### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ See `Building a Charm from Layers`_ for more information on how to use the
 charms.reactive framework. Also look at the `layer-basic documentation`_ for more
 info on how to use the basic layer.
 
-.. _Building a Charm from Layers: https://jujucharms.com/docs/stable/authors-charm-building
+.. _Building a Charm from Layers: https://web.archive.org/web/20160319143647/https://jujucharms.com/docs/stable/authors-charm-building
 .. _layer-basic documentation: https://github.com/juju-solutions/layer-basic/blob/master/README.md
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,12 @@ easier with an `Operator Framework <https://juju.is/about>`_ charm.
 
 Usage
 -----
-Look at the `layer-basic documentation`_ for more info on how to use the basic layer.
 
+See `Building a Charm from Layers`_ for more information on how to use the
+charms.reactive framework. Also look at the `layer-basic documentation`_ for more
+info on how to use the basic layer.
+
+.. _Building a Charm from Layers: https://jujucharms.com/docs/stable/authors-charm-building
 .. _layer-basic documentation: https://github.com/juju-solutions/layer-basic/blob/master/README.md
 
 Contributing


### PR DESCRIPTION
When creating #247 I did not think of using a link from archive.org.

While reactive charms are certainly deprecated, for various reasons,
they are still in use, and we need working documentation to onboard new
developers.
